### PR TITLE
Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Git and GitHub
+.github/
+.git/
+.gitignore
+.gitattributes
+
+# Gradle
+.gradle/
+**/build/
+
+# Docker
+.dockerignore
+Dockerfile*
+
+# Unused resources
+resources/3dcitydb
+resources/javadoc
+resources/license
+resources/samples
+LICENSE
+*.md

--- a/.github/workflows/docker-build-push-edge.yml
+++ b/.github/workflows/docker-build-push-edge.yml
@@ -84,3 +84,6 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: ${{ env.PLATFORMS }}
+    -
+      name: Image digest
+      run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-build-push-edge.yml
+++ b/.github/workflows/docker-build-push-edge.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - docker
 env:
   IMAGE_NAME: citydb-tool
   PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/docker-build-push-edge.yml
+++ b/.github/workflows/docker-build-push-edge.yml
@@ -71,16 +71,19 @@ jobs:
           org.opencontainers.image.title=3D City Database 5.0 CLI tool Docker image
           org.opencontainers.image.description=3D City Database 5.0 CLI to import/export city model data and to run database operations
           org.opencontainers.image.url=https://github.com/3dcitydb/
-          org.opencontainers.image.documentation=https://github.com/3dcitydb/citydb-tool
+          org.opencontainers.image.documentation=https://github.com/3dcitydb/citydb-tool#docker
           org.opencontainers.image.source=https://github.com/3dcitydb/citydb-tool
     -
       name: Build and publish
       uses: docker/build-push-action@v5
+      id: docker_build
       with:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: ${{ env.PLATFORMS }}
+        build-args: |
+          CITYDB_TOOL_VERSION=${{ steps.short-sha.outputs.sha }}
     -
       name: Image digest
       run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-build-push-edge.yml
+++ b/.github/workflows/docker-build-push-edge.yml
@@ -2,11 +2,9 @@ name: docker-build-push-edge
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches:
       - main
-      - docker
 env:
   IMAGE_NAME: citydb-tool
   PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
@@ -44,7 +42,6 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-
     -
       name: Set up QEMU
       uses: docker/setup-qemu-action@v3
@@ -53,7 +50,6 @@ jobs:
     -
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-
     -
       name: Extract metadata (tags, labels) for docker image
       id: meta
@@ -65,15 +61,15 @@ jobs:
         flavor: |
           latest=false
         tags: |
-          type=edge,branch=docker
+          type=edge,branch=main
         labels: |
           maintainer=Bruno Willenborg
           maintainer.email=b.willenborg(at)tum.de
           maintainer.organization=Chair of Geoinformatics, Technical University of Munich (TUM)
           org.opencontainers.image.authors=Bruno Willenborg
           org.opencontainers.image.vendor=3DCityDB Steering Committee
-          org.opencontainers.image.title=3D City Database Tool Docker image
-          org.opencontainers.image.description=Docker image for the 3D City Database Tool
+          org.opencontainers.image.title=3D City Database 5.0 CLI tool Docker image
+          org.opencontainers.image.description=3D City Database 5.0 CLI to import/export city model data and to run database operations
           org.opencontainers.image.url=https://github.com/3dcitydb/
           org.opencontainers.image.documentation=https://github.com/3dcitydb/citydb-tool
           org.opencontainers.image.source=https://github.com/3dcitydb/citydb-tool

--- a/.github/workflows/docker-build-push-edge.yml
+++ b/.github/workflows/docker-build-push-edge.yml
@@ -1,0 +1,86 @@
+name: docker-build-push-edge
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+env:
+  IMAGE_NAME: citydb-tool
+  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
+
+jobs:
+  build-push:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    -
+      name: Parse short sha
+      uses: benjlevesque/short-sha@v2.2
+      id: short-sha
+    -
+      name: set lower case owner name
+      run: |
+        echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+      env:
+        OWNER: '${{ github.repository_owner }}'
+    -
+      name: Checkout repo
+      uses: actions/checkout@v4
+    -
+      name: Docker login Dockerhub
+      id: docker_login
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    -
+      name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    -
+      name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: ${{ env.PLATFORMS }}
+    -
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    -
+      name: Extract metadata (tags, labels) for docker image
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}
+          ghcr.io/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}
+        flavor: |
+          latest=false
+        tags: |
+          type=edge,branch=docker
+        labels: |
+          maintainer=Bruno Willenborg
+          maintainer.email=b.willenborg(at)tum.de
+          maintainer.organization=Chair of Geoinformatics, Technical University of Munich (TUM)
+          org.opencontainers.image.authors=Bruno Willenborg
+          org.opencontainers.image.vendor=3DCityDB Steering Committee
+          org.opencontainers.image.title=3D City Database Tool Docker image
+          org.opencontainers.image.description=Docker image for the 3D City Database Tool
+          org.opencontainers.image.url=https://github.com/3dcitydb/
+          org.opencontainers.image.documentation=https://github.com/3dcitydb/citydb-tool
+          org.opencontainers.image.source=https://github.com/3dcitydb/citydb-tool
+    -
+      name: Build and publish
+      uses: docker/build-push-action@v5
+      with:
+        push: false
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: ${{ env.PLATFORMS }}

--- a/.github/workflows/docker-build-push-edge.yml
+++ b/.github/workflows/docker-build-push-edge.yml
@@ -77,7 +77,7 @@ jobs:
       name: Build and publish
       uses: docker/build-push-action@v5
       with:
-        push: false
+        push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: ${{ env.PLATFORMS }}

--- a/.github/workflows/docker-build-push-release.yml
+++ b/.github/workflows/docker-build-push-release.yml
@@ -58,7 +58,7 @@ jobs:
           ${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}
           ghcr.io/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}
         flavor: |
-          latest=$${{ !github.event.release.prerelease }}
+          latest=${{ !github.event.release.prerelease }}
         tags: |
           type=semver,pattern={{version}}
         labels: |

--- a/.github/workflows/docker-build-push-release.yml
+++ b/.github/workflows/docker-build-push-release.yml
@@ -1,0 +1,85 @@
+name: docker-build-push-release
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published, edited]
+env:
+  IMAGE_NAME: citydb-tool
+  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
+
+jobs:
+  build-push:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    -
+      name: Parse short sha
+      uses: benjlevesque/short-sha@v2.2
+      id: short-sha
+    -
+      name: set lower case owner name
+      run: |
+        echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+      env:
+        OWNER: '${{ github.repository_owner }}'
+    -
+      name: Checkout repo
+      uses: actions/checkout@v4
+    -
+      name: Docker login Dockerhub
+      id: docker_login
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    -
+      name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    -
+      name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: ${{ env.PLATFORMS }}
+    -
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    -
+      name: Extract metadata (tags, labels) for docker image
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}
+          ghcr.io/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}
+        flavor: |
+          latest=$${{ !github.event.release.prerelease }}
+        tags: |
+          type=semver,pattern={{version}}
+        labels: |
+          maintainer=Bruno Willenborg
+          maintainer.email=b.willenborg(at)tum.de
+          maintainer.organization=Chair of Geoinformatics, Technical University of Munich (TUM)
+          org.opencontainers.image.authors=Bruno Willenborg
+          org.opencontainers.image.vendor=3DCityDB Steering Committee
+          org.opencontainers.image.title=3D City Database 5.0 CLI tool Docker image
+          org.opencontainers.image.description=3D City Database 5.0 CLI to import/export city model data and to run database operations
+          org.opencontainers.image.url=https://github.com/3dcitydb/
+          org.opencontainers.image.documentation=https://github.com/3dcitydb/citydb-tool
+          org.opencontainers.image.source=https://github.com/3dcitydb/citydb-tool
+    -
+      name: Build and publish
+      uses: docker/build-push-action@v5
+      with:
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: ${{ env.PLATFORMS }}
+    -
+      name: Image digest
+      run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-build-push-release.yml
+++ b/.github/workflows/docker-build-push-release.yml
@@ -15,9 +15,9 @@ jobs:
 
     steps:
     -
-      name: Parse short sha
-      uses: benjlevesque/short-sha@v2.2
-      id: short-sha
+      name: Get release version without v
+      id: release_version
+      uses: battila7/get-version-action@v2
     -
       name: set lower case owner name
       run: |
@@ -70,16 +70,19 @@ jobs:
           org.opencontainers.image.title=3D City Database 5.0 CLI tool Docker image
           org.opencontainers.image.description=3D City Database 5.0 CLI to import/export city model data and to run database operations
           org.opencontainers.image.url=https://github.com/3dcitydb/
-          org.opencontainers.image.documentation=https://github.com/3dcitydb/citydb-tool
+          org.opencontainers.image.documentation=https://github.com/3dcitydb/citydb-tool#docker
           org.opencontainers.image.source=https://github.com/3dcitydb/citydb-tool
     -
       name: Build and publish
       uses: docker/build-push-action@v5
+      id: docker_build
       with:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: ${{ env.PLATFORMS }}
+        build-args: |
+          CITYDB_TOOL_VERSION=${{ steps.release_version.outputs.version }}
     -
       name: Image digest
       run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 
 # Fetch & build stage #########################################################
 # ARGS
-ARG BUILDER_IMAGE_TAG='17-jdk-slim'
-ARG RUNTIME_IMAGE_TAG='17-slim'
+ARG BUILDER_IMAGE_TAG='11-jdk-slim'
+ARG RUNTIME_IMAGE_TAG='11-slim'
 
 # Base image
 FROM openjdk:${BUILDER_IMAGE_TAG} AS builder
@@ -27,7 +27,7 @@ ARG CITYDB_TOOL_VERSION
 ENV CITYDB_TOOL_VERSION=${CITYDB_TOOL_VERSION}
 
 # Copy from builder
-COPY --from=builder /build/citydb-cli/build/install/citydb /opt/citydb-tool
+COPY --from=builder /build/citydb-cli/build/install/3DCityDB-Command-Line-Tool /opt/citydb-tool
 
 # Run as non-root user
 RUN groupadd --gid 1000 -r citydb-tool && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,12 +29,10 @@ ENV CITYDB_TOOL_VERSION=${CITYDB_TOOL_VERSION}
 # Copy from builder
 COPY --from=builder /build/citydb-cli/build/install/3DCityDB-Command-Line-Tool /opt/citydb-tool
 
-# Run as non-root user
+# Run as non-root user, put start script in path and set permissions
 RUN groupadd --gid 1000 -r citydb-tool && \
-    useradd --uid 1000 --gid 1000 -d /data -m -r --no-log-init citydb-tool
-
-# Put start script in path and set permissions
-RUN ln -sf /opt/citydb-tool/citydb /usr/local/bin
+    useradd --uid 1000 --gid 1000 -d /data -m -r --no-log-init citydb-tool && \
+    ln -sf /opt/citydb-tool/citydb /usr/local/bin
 
 WORKDIR /data
 USER 1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@
 
 # Fetch & build stage #########################################################
 # ARGS
-ARG BUILDER_IMAGE_TAG='11-jdk-slim'
-ARG RUNTIME_IMAGE_TAG='11-slim'
+ARG BUILDER_IMAGE_TAG='11-jdk-jammy'
+ARG RUNTIME_IMAGE_TAG='11-jdk-jammy'
 
 # Base image
-FROM openjdk:${BUILDER_IMAGE_TAG} AS builder
+FROM eclipse-temurin:${BUILDER_IMAGE_TAG} AS builder
 
 # Copy source code
 WORKDIR /build
@@ -20,7 +20,7 @@ RUN chmod u+x ./gradlew && ./gradlew installDist
 
 # Runtime stage ###############################################################
 # Base image
-FROM openjdk:${RUNTIME_IMAGE_TAG} AS runtime
+FROM eclipse-temurin:${RUNTIME_IMAGE_TAG} AS runtime
 
 # Version info
 ARG CITYDB_TOOL_VERSION
@@ -41,9 +41,3 @@ USER 1000
 
 ENTRYPOINT ["citydb"]
 CMD ["--help"]
-
-# Labels ######################################################################
-LABEL maintainer="Bruno Willenborg"
-LABEL maintainer.email="b.willenborg(at)tum.de"
-LABEL maintainer.organization="Chair of Geoinformatics, Technical University of Munich (TUM)"
-LABEL source.repo="https://github.com/3dcitydb/importer-exporter"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# 3DCityDB Importer/Exporter Dockerfile #######################################
+#   Official website    https://www.3dcitydb.org
+#   GitHub              https://github.com/3dcitydb/citydb-tool
+###############################################################################
+
+# Fetch & build stage #########################################################
+# ARGS
+ARG BUILDER_IMAGE_TAG='17-jdk-slim'
+ARG RUNTIME_IMAGE_TAG='17-slim'
+
+# Base image
+FROM openjdk:${BUILDER_IMAGE_TAG} AS builder
+
+# Copy source code
+WORKDIR /build
+COPY . /build
+
+# Build
+RUN chmod u+x ./gradlew && ./gradlew installDist
+
+# Runtime stage ###############################################################
+# Base image
+FROM openjdk:${RUNTIME_IMAGE_TAG} AS runtime
+
+# Version info
+ARG CITYDB_TOOL_VERSION
+ENV CITYDB_TOOL_VERSION=${CITYDB_TOOL_VERSION}
+
+# Copy from builder
+COPY --from=builder /build/citydb-cli/build/install/citydb /opt/citydb-tool
+
+# Run as non-root user
+RUN groupadd --gid 1000 -r citydb-tool && \
+    useradd --uid 1000 --gid 1000 -d /data -m -r --no-log-init citydb-tool
+
+# Put start script in path and set permissions
+RUN ln -sf /opt/citydb-tool/citydb /usr/local/bin
+
+WORKDIR /data
+USER 1000
+
+ENTRYPOINT ["citydb"]
+CMD ["--help"]
+
+# Labels ######################################################################
+LABEL maintainer="Bruno Willenborg"
+LABEL maintainer.email="b.willenborg(at)tum.de"
+LABEL maintainer.organization="Chair of Geoinformatics, Technical University of Munich (TUM)"
+LABEL source.repo="https://github.com/3dcitydb/importer-exporter"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 
 # Fetch & build stage #########################################################
 # ARGS
-ARG BUILDER_IMAGE_TAG='11-jdk-jammy'
-ARG RUNTIME_IMAGE_TAG='11-jdk-jammy'
+ARG BUILDER_IMAGE_TAG='17-jdk-jammy'
+ARG RUNTIME_IMAGE_TAG='17-jdk-jammy'
 
 # Base image
 FROM eclipse-temurin:${BUILDER_IMAGE_TAG} AS builder

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ The citydb-tool can be run on any platform providing appropriate Java support.
 
 ## Docker
 
+[![Docker edge image build](https://img.shields.io/github/actions/workflow/status/3dcitydb/citydb-tool/docker-build-push-edge.yml?label=edge&logo=docker)](https://github.com/users/3dcitydb/packages/container/package/citydb-tool)
+
 Currently, we offer an `edge` Docker image of the tool, which is built
 from the latest commit to the `main` branch. The image supports the most
 common architectures (`amd64`, `arm64`, `arm/v7`) and is available from

--- a/README.md
+++ b/README.md
@@ -1,22 +1,29 @@
 # citydb-tool
+
 3D City Database 5.0 CLI to import/export city model data and to run database operations
 
 ## License
+
 The citydb-tool is licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
 See the `LICENSE` file for more details.
 
 ## Latest release
+
 The latest stable release of the citydb-tool is `0.5-beta`.
 
 ## Contributing
+
 * To file bugs found in the software create a GitHub issue.
 * To contribute code for fixing filed issues create a pull request with the issue id.
 * To propose a new feature create a GitHub issue and open a discussion.
 
 ## Using
+
 Download and unzip the latest release or [build](https://github.com/3dcitydb/citydb-tool#building) the program from
 source. Afterwards, open a shell environment and run the `citydb` script from the program folder to launch the
 program.
+Another option is to use the
+[`citydb-tool` Docker image](https://github.com/3dcitydb/citydb-tool#docker).
 
 To show the help message and all available commands of the citydb-tool, simply type the following:
 
@@ -49,11 +56,40 @@ the command you want to learn more about:
     > citydb help COMMAND
 
 ## System requirements
+
 * Java 11 or higher
 
 The citydb-tool can be run on any platform providing appropriate Java support.
 
+## Docker
+
+Currently, we offer an `edge` Docker image of the tool, which is built
+from the latest commit to the `main` branch. The image supports the most
+common architectures (`amd64`, `arm64`, `arm/v7`) and is available from
+Dockerhub or Github packages.
+
+    docker pull 3dcitydb/citydb-tool:edge
+    docker pull ghcr.io/3dcitydb/citydb-tool:edge
+
+### Synopsis
+
+The Docker image exposes the commands of the `citydb-tool`, as described
+in the [usage section](https://github.com/3dcitydb/citydb-tool#usage).
+The environment variables listed below can be used to specify a
+3DCityDB v5 connection. To exchange data with the container, mount a host folder to `/data` inside the container.
+
+    docker run --rm --name citydb-tool [-i -t] \
+        [-e CITYDB_HOST=the.host.de] \
+        [-e CITYDB_PORT=5432] \
+        [-e CITYDB_NAME=theDBName] \
+        [-e CITYDB_SCHEMA=theCityDBSchemaName] \
+        [-e CITYDB_USERNAME=theUsername] \
+        [-e CITYDB_PASSWORD=theSecretPass] \
+        [-v /my/data/:/data] \
+    3dcitydb/citydb-tool[:TAG] COMMAND
+
 ## Building
+
 The citydb-tool uses [Gradle](https://gradle.org/) as build system. To build the program from source, clone the
 repository to your local machine and run the following command from the root of the repository.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Gradle build](https://img.shields.io/github/actions/workflow/status/3dcitydb/citydb-tool/build-citydb-tool.yml?logo=Gradle&logoColor=white&style=flat-square) [![Docker edge image build](https://img.shields.io/github/actions/workflow/status/3dcitydb/citydb-tool/docker-build-push-edge.yml?label=edge&logo=docker)](https://github.com/users/3dcitydb/packages/container/package/citydb-tool)
+![Gradle build](https://img.shields.io/github/actions/workflow/status/3dcitydb/citydb-tool/build-citydb-tool.yml?logo=Gradle&logoColor=white&style=flat-square) [![Docker edge image build](https://img.shields.io/github/actions/workflow/status/3dcitydb/citydb-tool/docker-build-push-edge.yml?label=edge&logo=docker&style=flat-square)](https://github.com/users/3dcitydb/packages/container/package/citydb-tool)
 
 # citydb-tool
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Gradle build](https://img.shields.io/github/actions/workflow/status/3dcitydb/citydb-tool/build-citydb-tool.yml?logo=Gradle&logoColor=white&style=flat-square)
+![Gradle build](https://img.shields.io/github/actions/workflow/status/3dcitydb/citydb-tool/build-citydb-tool.yml?logo=Gradle&logoColor=white&style=flat-square) [![Docker edge image build](https://img.shields.io/github/actions/workflow/status/3dcitydb/citydb-tool/docker-build-push-edge.yml?label=edge&logo=docker)](https://github.com/users/3dcitydb/packages/container/package/citydb-tool)
 
 # citydb-tool
 
@@ -64,8 +64,6 @@ the command you want to learn more about:
 The citydb-tool can be run on any platform providing appropriate Java support.
 
 ## Docker
-
-[![Docker edge image build](https://img.shields.io/github/actions/workflow/status/3dcitydb/citydb-tool/docker-build-push-edge.yml?label=edge&logo=docker)](https://github.com/users/3dcitydb/packages/container/package/citydb-tool)
 
 Currently, we offer an `edge` Docker image of the tool, which is built
 from the latest commit to the `main` branch. The image supports the most


### PR DESCRIPTION
This used to be #3.

This PR adds a build workflow and `Dockerfile` for a Docker image for the `citydb-tool`.

### Features

- [x] Publish to Dockerhub and Github packages
  - `3dcitydb/citydb-tool:edge`
  - `ghcr.io/3dcitydb/citydb-tool:edge`
  - Test images are here aleady: https://github.com/BWibo/citydb-tool/pkgs/container/citydb-tool
  - Currently, only an `edge` image build from the latest commit to `main`
- [x] Build for common platforms `amd64`, `arm64`, `arm/v7`
- [x] Use new base image, as OpenJDK is deprecated, see https://hub.docker.com/_/openjdk
- [x] Document new image

### Synopsis

    docker run --rm --name citydb-tool [-i -t] \
        [-e CITYDB_HOST=the.host.de] \
        [-e CITYDB_PORT=5432] \
        [-e CITYDB_NAME=theDBName] \
        [-e CITYDB_SCHEMA=theCityDBSchemaName] \
        [-e CITYDB_USERNAME=theUsername] \
        [-e CITYDB_PASSWORD=theSecretPass] \
        [-v /my/data/:/data] \
      3dcitydb/citydb-tool[:TAG] COMMAND


