### PR TITLE
[Fix]: Docker build

### DIFF
--- a/.github/workflows/docker-build-push-edge.yml
+++ b/.github/workflows/docker-build-push-edge.yml
@@ -7,7 +7,7 @@ on:
       - main
 env:
   IMAGE_NAME: citydb-tool
-  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
+  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   build-push:

--- a/.github/workflows/docker-build-push-edge.yml
+++ b/.github/workflows/docker-build-push-edge.yml
@@ -7,13 +7,16 @@ on:
       - main
 env:
   IMAGE_NAME: citydb-tool
-  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   build-push:
-
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
     -
       name: Parse short sha
@@ -46,7 +49,7 @@ jobs:
       name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:
-        platforms: ${{ env.PLATFORMS }}
+        platforms: ${{ matrix.platform }}
     -
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -81,7 +84,7 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        platforms: ${{ env.PLATFORMS }}
+        platforms: ${{ matrix.platform }}
         build-args: |
           CITYDB_TOOL_VERSION=${{ steps.short-sha.outputs.sha }}
     -

--- a/.github/workflows/docker-build-push-release.yml
+++ b/.github/workflows/docker-build-push-release.yml
@@ -6,13 +6,16 @@ on:
     types: [published, edited]
 env:
   IMAGE_NAME: citydb-tool
-  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
 jobs:
   build-push:
-
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
     -
       name: Get release version without v
@@ -45,7 +48,7 @@ jobs:
       name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:
-        platforms: ${{ env.PLATFORMS }}
+        platforms: ${{ matrix.platform }}
     -
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -80,7 +83,7 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        platforms: ${{ env.PLATFORMS }}
+        platforms: ${{ matrix.platform }}
         build-args: |
           CITYDB_TOOL_VERSION=${{ steps.release_version.outputs.version }}
     -


### PR DESCRIPTION
This PR fixes the docker build workflow by dropping the `arm/v7` arch. This should be fine, as `amd64` and `arm64` are probably the only platforms that are really relevant for `citydb-tool` right now. 
Additionally, platforms are now distributed across runners to speed up the build process. 