### PR TITLE
Improve export of local feature references

### DIFF
--- a/citydb-model/src/main/java/org/citydb/model/appearance/SurfaceDataProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/appearance/SurfaceDataProperty.java
@@ -29,19 +29,15 @@ import java.util.Objects;
 import java.util.Optional;
 
 public class SurfaceDataProperty extends Child implements InlineOrByReferenceProperty<SurfaceData<?>> {
-    private final SurfaceData<?> surfaceData;
-    private final Reference reference;
+    private SurfaceData<?> surfaceData;
+    private Reference reference;
 
     private SurfaceDataProperty(SurfaceData<?> surfaceData) {
-        Objects.requireNonNull(surfaceData, "The surface data must not be null.");
-        this.surfaceData = asChild(surfaceData);
-        reference = null;
+        setObject(Objects.requireNonNull(surfaceData, "The surface data must not be null."));
     }
 
     private SurfaceDataProperty(Reference reference) {
-        Objects.requireNonNull(reference, "The reference must not be null.");
-        this.reference = asChild(reference);
-        surfaceData = null;
+        setReference(Objects.requireNonNull(reference, "The reference must not be null."));
     }
 
     public static SurfaceDataProperty of(SurfaceData<?> surfaceData) {
@@ -58,7 +54,27 @@ public class SurfaceDataProperty extends Child implements InlineOrByReferencePro
     }
 
     @Override
+    public SurfaceDataProperty setObject(SurfaceData<?> surfaceData) {
+        if (surfaceData != null) {
+            this.surfaceData = asChild(surfaceData);
+            reference = null;
+        }
+
+        return this;
+    }
+
+    @Override
     public Optional<Reference> getReference() {
         return Optional.ofNullable(reference);
+    }
+
+    @Override
+    public SurfaceDataProperty setReference(Reference reference) {
+        if (reference != null) {
+            this.reference = asChild(reference);
+            surfaceData = null;
+        }
+
+        return this;
     }
 }

--- a/citydb-model/src/main/java/org/citydb/model/appearance/TextureImageProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/appearance/TextureImageProperty.java
@@ -30,19 +30,15 @@ import java.util.Objects;
 import java.util.Optional;
 
 public class TextureImageProperty implements InlineOrByReferenceProperty<ExternalFile>, Serializable {
-    private final ExternalFile textureImage;
-    private final Reference reference;
+    private ExternalFile textureImage;
+    private Reference reference;
 
     private TextureImageProperty(ExternalFile textureImage) {
-        Objects.requireNonNull(textureImage, "The texture image must not be null.");
-        this.textureImage = textureImage;
-        reference = null;
+        setObject(Objects.requireNonNull(textureImage, "The texture image must not be null."));
     }
 
     private TextureImageProperty(Reference reference) {
-        Objects.requireNonNull(reference, "The reference must not be null.");
-        this.reference = reference;
-        textureImage = null;
+        setReference(Objects.requireNonNull(reference, "The reference must not be null."));
     }
 
     public static TextureImageProperty of(ExternalFile textureImage) {
@@ -59,7 +55,27 @@ public class TextureImageProperty implements InlineOrByReferenceProperty<Externa
     }
 
     @Override
+    public TextureImageProperty setObject(ExternalFile textureImage) {
+        if (textureImage != null) {
+            this.textureImage = textureImage;
+            reference = null;
+        }
+
+        return this;
+    }
+
+    @Override
     public Optional<Reference> getReference() {
         return Optional.ofNullable(reference);
+    }
+
+    @Override
+    public TextureImageProperty setReference(Reference reference) {
+        if (reference != null) {
+            this.reference = reference;
+            textureImage = null;
+        }
+
+        return this;
     }
 }

--- a/citydb-model/src/main/java/org/citydb/model/common/InlineOrByReferenceProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/common/InlineOrByReferenceProperty.java
@@ -25,5 +25,7 @@ import java.util.Optional;
 
 public interface InlineOrByReferenceProperty<T extends Referencable> {
     Optional<T> getObject();
+    InlineOrByReferenceProperty<T> setObject(T object);
     Optional<Reference> getReference();
+    InlineOrByReferenceProperty<T> setReference(Reference reference);
 }

--- a/citydb-model/src/main/java/org/citydb/model/common/InlineProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/common/InlineProperty.java
@@ -23,4 +23,5 @@ package org.citydb.model.common;
 
 public interface InlineProperty<T extends Referencable> {
     T getObject();
+    InlineProperty<T> setObject(T object);
 }

--- a/citydb-model/src/main/java/org/citydb/model/property/AddressProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/AddressProperty.java
@@ -30,21 +30,17 @@ import java.util.Objects;
 import java.util.Optional;
 
 public class AddressProperty extends Property<AddressProperty> implements InlineOrByReferenceProperty<Address> {
-    private final Address address;
-    private final Reference reference;
+    private Address address;
+    private Reference reference;
 
     private AddressProperty(Name name, Address address) {
         super(name, DataType.ADDRESS_PROPERTY);
-        Objects.requireNonNull(address, "The address must not be null.");
-        this.address = asChild(address);
-        reference = null;
+        setObject(Objects.requireNonNull(address, "The address must not be null."));
     }
 
     private AddressProperty(Name name, Reference reference) {
         super(name, DataType.ADDRESS_PROPERTY);
-        Objects.requireNonNull(reference, "The reference must not be null.");
-        this.reference = asChild(reference);
-        address = null;
+        setReference(Objects.requireNonNull(reference, "The reference must not be null."));
     }
 
     public static AddressProperty of(Name name, Address address) {
@@ -61,8 +57,28 @@ public class AddressProperty extends Property<AddressProperty> implements Inline
     }
 
     @Override
+    public AddressProperty setObject(Address address) {
+        if (address != null) {
+            this.address = asChild(address);
+            reference = null;
+        }
+
+        return this;
+    }
+
+    @Override
     public Optional<Reference> getReference() {
         return Optional.ofNullable(reference);
+    }
+
+    @Override
+    public AddressProperty setReference(Reference reference) {
+        if (reference != null) {
+            this.reference = asChild(reference);
+            address = null;
+        }
+
+        return this;
     }
 
     @Override

--- a/citydb-model/src/main/java/org/citydb/model/property/AppearanceProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/AppearanceProperty.java
@@ -28,12 +28,11 @@ import org.citydb.model.common.Name;
 import java.util.Objects;
 
 public class AppearanceProperty extends Property<AppearanceProperty> implements InlineProperty<Appearance> {
-    private final Appearance appearance;
+    private Appearance appearance;
 
     private AppearanceProperty(Name name, Appearance appearance) {
         super(name, DataType.APPEARANCE_PROPERTY);
-        Objects.requireNonNull(appearance, "The appearance must not be null.");
-        this.appearance = asChild(appearance);
+        setObject(Objects.requireNonNull(appearance, "The appearance must not be null."));
     }
 
     public static AppearanceProperty of(Name name, Appearance appearance) {
@@ -43,6 +42,15 @@ public class AppearanceProperty extends Property<AppearanceProperty> implements 
     @Override
     public Appearance getObject() {
         return appearance;
+    }
+
+    @Override
+    public AppearanceProperty setObject(Appearance appearance) {
+        if (appearance != null) {
+            this.appearance = asChild(appearance);
+        }
+
+        return this;
     }
 
     @Override

--- a/citydb-model/src/main/java/org/citydb/model/property/FeatureProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/FeatureProperty.java
@@ -30,21 +30,17 @@ import java.util.Objects;
 import java.util.Optional;
 
 public class FeatureProperty extends Property<FeatureProperty> implements InlineOrByReferenceProperty<Feature> {
-    private final Feature feature;
-    private final Reference reference;
+    private Feature feature;
+    private Reference reference;
 
     private FeatureProperty(Name name, Feature feature) {
         super(name, DataType.FEATURE_PROPERTY);
-        Objects.requireNonNull(feature, "The feature must not be null.");
-        this.feature = asChild(feature);
-        reference = null;
+        setObject(Objects.requireNonNull(feature, "The feature must not be null."));
     }
 
     private FeatureProperty(Name name, Reference reference) {
         super(name, DataType.FEATURE_PROPERTY);
-        Objects.requireNonNull(reference, "The reference must not be null.");
-        this.reference = asChild(reference);
-        feature = null;
+        setReference(Objects.requireNonNull(reference, "The reference must not be null."));
     }
 
     public static FeatureProperty of(Name name, Feature feature) {
@@ -61,8 +57,28 @@ public class FeatureProperty extends Property<FeatureProperty> implements Inline
     }
 
     @Override
+    public FeatureProperty setObject(Feature feature) {
+        if (feature != null) {
+            this.feature = asChild(feature);
+            reference = null;
+        }
+
+        return this;
+    }
+
+    @Override
     public Optional<Reference> getReference() {
         return Optional.ofNullable(reference);
+    }
+
+    @Override
+    public FeatureProperty setReference(Reference reference) {
+        if (reference != null) {
+            this.reference = asChild(reference);
+            feature = null;
+        }
+
+        return this;
     }
 
     @Override

--- a/citydb-model/src/main/java/org/citydb/model/property/GeometryProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/GeometryProperty.java
@@ -29,13 +29,12 @@ import java.util.Objects;
 import java.util.Optional;
 
 public class GeometryProperty extends Property<GeometryProperty> implements InlineProperty<Geometry<?>> {
-    private final Geometry<?> geometry;
+    private Geometry<?> geometry;
     private String lod;
 
     private GeometryProperty(Name name, Geometry<?> geometry) {
         super(name, DataType.GEOMETRY_PROPERTY);
-        Objects.requireNonNull(geometry, "The geometry must not be null.");
-        this.geometry = asChild(geometry);
+        setObject(Objects.requireNonNull(geometry, "The geometry must not be null."));
     }
 
     public static GeometryProperty of(Name name, Geometry<?> geometry) {
@@ -45,6 +44,15 @@ public class GeometryProperty extends Property<GeometryProperty> implements Inli
     @Override
     public Geometry<?> getObject() {
         return geometry;
+    }
+
+    @Override
+    public GeometryProperty setObject(Geometry<?> geometry) {
+        if (geometry != null) {
+            this.geometry = asChild(geometry);
+        }
+
+        return this;
     }
 
     public Optional<String> getLod() {

--- a/citydb-model/src/main/java/org/citydb/model/property/ImplicitGeometryProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/ImplicitGeometryProperty.java
@@ -33,24 +33,20 @@ import java.util.Objects;
 import java.util.Optional;
 
 public class ImplicitGeometryProperty extends Property<ImplicitGeometryProperty> implements InlineOrByReferenceProperty<ImplicitGeometry> {
-    private final ImplicitGeometry implicitGeometry;
-    private final Reference reference;
+    private ImplicitGeometry implicitGeometry;
+    private Reference reference;
     private List<Double> transformationMatrix;
     private Point referencePoint;
     private String lod;
 
     private ImplicitGeometryProperty(Name name, ImplicitGeometry implicitGeometry) {
         super(name, DataType.IMPLICIT_GEOMETRY_PROPERTY);
-        Objects.requireNonNull(implicitGeometry, "The implicit geometry must not be null.");
-        this.implicitGeometry = asChild(implicitGeometry);
-        reference = null;
+        setObject(Objects.requireNonNull(implicitGeometry, "The implicit geometry must not be null."));
     }
 
     private ImplicitGeometryProperty(Name name, Reference reference) {
         super(name, DataType.IMPLICIT_GEOMETRY_PROPERTY);
-        Objects.requireNonNull(reference, "The reference must not be null.");
-        this.reference = asChild(reference);
-        implicitGeometry = null;
+        setReference(Objects.requireNonNull(reference, "The reference must not be null."));
     }
 
     public static ImplicitGeometryProperty of(Name name, ImplicitGeometry implicitGeometry) {
@@ -67,8 +63,28 @@ public class ImplicitGeometryProperty extends Property<ImplicitGeometryProperty>
     }
 
     @Override
+    public ImplicitGeometryProperty setObject(ImplicitGeometry implicitGeometry) {
+        if (implicitGeometry != null) {
+            this.implicitGeometry = asChild(implicitGeometry);
+            reference = null;
+        }
+
+        return this;
+    }
+
+    @Override
     public Optional<Reference> getReference() {
         return Optional.ofNullable(reference);
+    }
+
+    @Override
+    public ImplicitGeometryProperty setReference(Reference reference) {
+        if (reference != null) {
+            this.reference = asChild(reference);
+            implicitGeometry = null;
+        }
+
+        return this;
     }
 
     public Optional<List<Double>> getTransformationMatrix() {

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/ExportOptions.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/ExportOptions.java
@@ -38,6 +38,7 @@ public class ExportOptions {
     private OutputFile outputFile;
     private int numberOfThreads;
     private int numberOfTextureBuckets;
+    private boolean resolveLocalReferences = true;
 
     private ExportOptions() {
     }
@@ -89,6 +90,15 @@ public class ExportOptions {
             this.numberOfTextureBuckets = numberOfTextureBuckets;
         }
 
+        return this;
+    }
+
+    public boolean isResolveLocalReferences() {
+        return resolveLocalReferences;
+    }
+
+    public ExportOptions setResolveLocalReferences(boolean resolveLocalReferences) {
+        this.resolveLocalReferences = resolveLocalReferences;
         return this;
     }
 }

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/feature/FeatureExporter.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/feature/FeatureExporter.java
@@ -32,8 +32,6 @@ import org.citydb.operation.exporter.hierarchy.HierarchyBuilder;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.OffsetDateTime;
-import java.util.Collections;
-import java.util.Set;
 
 public class FeatureExporter extends DatabaseExporter {
 
@@ -43,14 +41,10 @@ public class FeatureExporter extends DatabaseExporter {
     }
 
     public Feature doExport(long id) throws ExportException, SQLException {
-        return doExport(id, Collections.emptySet());
-    }
-
-    public Feature doExport(long id, Set<Long> exportedFeatures) throws ExportException, SQLException {
         stmt.setLong(1, id);
         try (ResultSet rs = stmt.executeQuery()) {
-            return HierarchyBuilder.newInstance(helper)
-                    .initialize(rs, exportedFeatures)
+            return HierarchyBuilder.newInstance(id, helper)
+                    .initialize(rs)
                     .build()
                     .getFeature(id);
         }

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/hierarchy/Hierarchy.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/hierarchy/Hierarchy.java
@@ -26,21 +26,20 @@ import org.citydb.model.appearance.Appearance;
 import org.citydb.model.feature.Feature;
 import org.citydb.model.geometry.Geometry;
 import org.citydb.model.geometry.ImplicitGeometry;
+import org.citydb.model.property.FeatureProperty;
 import org.citydb.model.property.Property;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 public class Hierarchy {
     private final Map<Long, Feature> features = new HashMap<>();
-    private final Set<Long> inlineFeatures = new HashSet<>();
     private final Map<Long, Geometry<?>> geometries = new HashMap<>();
     private final Map<Long, ImplicitGeometry> implicitGeometries = new HashMap<>();
     private final Map<Long, Appearance> appearances = new HashMap<>();
     private final Map<Long, Address> addresses = new HashMap<>();
     private final Map<Long, Property<?>> properties = new HashMap<>();
+    private final Map<String, FeatureProperty> localReferences = new HashMap<>();
 
     Hierarchy() {
     }
@@ -57,18 +56,6 @@ public class Hierarchy {
         if (feature != null) {
             features.put(id, feature);
         }
-    }
-
-    Set<Long> getInlineFeatures() {
-        return inlineFeatures;
-    }
-
-    void addInlineFeature(long id) {
-        inlineFeatures.add(id);
-    }
-
-    boolean isInlineFeature(long id) {
-        return inlineFeatures.contains(id);
     }
 
     public Map<Long, Geometry<?>> getGeometries() {
@@ -143,6 +130,16 @@ public class Hierarchy {
     public void addProperty(long id, Property<?> property) {
         if (property != null) {
             properties.put(id, property);
+        }
+    }
+
+    public FeatureProperty getLocalReference(String target) {
+        return localReferences.get(target);
+    }
+
+    public void addLocalReference(String target, FeatureProperty property) {
+        if (property != null) {
+            localReferences.putIfAbsent(target, property);
         }
     }
 }


### PR DESCRIPTION
This PR proposes some improvements to the export of feature references:
- Global feature references (`val_reference_type` == 2) are never resolved but only exported as `Reference` of type `GLOBAL_REFERENCE`. This is a result of [#9](https://github.com/3dcitydb/citydb-tool/pull/9) but is differently implemented in this PR.
- Local feature references (`val_reference_type` == 1) can optionally be resolved. A corresponing option has been added to `ExportOptions`. This new option is true by default so that local references are resolved.
- When exporting local feature references, the code has been improved to better detect cycles. If there are multiple references to the same local feature, the feature is only exported once. All other references are exported as `Reference` of type `LOCAL_REFERENCE`.