### PR TITLE
Integrate and use new config module in all other modules

### DIFF
--- a/citydb-cli/build.gradle
+++ b/citydb-cli/build.gradle
@@ -5,13 +5,13 @@ plugins {
 }
 
 dependencies {
+    implementation project(':citydb-config')
     implementation project(':citydb-io')
     implementation project(':citydb-io-citygml')
     implementation project(':citydb-logging')
     implementation project(':citydb-database')
     implementation project(':citydb-operation')
     implementation project(':citydb-database-postgres')
-    api project(':citydb-config')
     api project(':citydb-plugin')
     api 'info.picocli:picocli:4.7.5'
 }

--- a/citydb-cli/src/main/java/module-info.java
+++ b/citydb-cli/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module org.citydb.cli {
+    requires org.citydb.config;
     requires org.citygml4j.core;
     requires org.citydb.io;
     requires org.citydb.io.citygml;
@@ -7,7 +8,6 @@ module org.citydb.cli {
     requires org.citydb.operation;
     requires transitive org.citydb.plugin;
     requires transitive info.picocli;
-    requires org.citydb.config;
 
     exports org.citydb.cli;
     exports org.citydb.cli.command;

--- a/citydb-cli/src/main/java/org/citydb/cli/Launcher.java
+++ b/citydb-cli/src/main/java/org/citydb/cli/Launcher.java
@@ -29,6 +29,7 @@ import org.citydb.cli.exporter.ExportCommand;
 import org.citydb.cli.extension.MainCommand;
 import org.citydb.cli.importer.ImportCommand;
 import org.citydb.cli.index.IndexCommand;
+import org.citydb.cli.option.ConfigOption;
 import org.citydb.cli.option.Option;
 import org.citydb.cli.util.CliConstants;
 import org.citydb.cli.util.CommandHelper;
@@ -68,6 +69,10 @@ import java.util.stream.Collectors;
                 CommandLine.HelpCommand.class
         })
 public class Launcher implements Command, CommandLine.IVersionProvider {
+    @CommandLine.Option(names = "--config-file", scope = CommandLine.ScopeType.INHERIT, paramLabel = "<file>",
+            description = "Load configuration from this file.")
+    private Path configFile;
+
     @CommandLine.Option(names = {"-L", "--log-level"}, scope = CommandLine.ScopeType.INHERIT, paramLabel = "<level>",
             defaultValue = "info", description = "Log level: ${COMPLETION-CANDIDATES} (default: ${DEFAULT-VALUE}).")
     private LogLevel logLevel;
@@ -90,17 +95,12 @@ public class Launcher implements Command, CommandLine.IVersionProvider {
                     "(default: ${MAP-FALLBACK-VALUE}).")
     private Map<String, Boolean> usePlugins;
 
-    @CommandLine.Option(names = "--config-file", scope = CommandLine.ScopeType.INHERIT, paramLabel = "<file>",
-            description = "Load configuration from this file.")
-    private Path configFile;
-
     private final Logger logger = LoggerManager.getInstance().getLogger();
     private final PluginManager pluginManager = PluginManager.getInstance();
-    private final ConfigManager configManager = ConfigManager.getInstance();
     private final CommandHelper helper = CommandHelper.of(logger);
+    private final Config config = new Config();
     private String commandLine;
     private String subCommandName;
-    private Config config;
 
     public static void main(String[] args) {
         Launcher launcher = new Launcher();
@@ -148,10 +148,6 @@ public class Launcher implements Command, CommandLine.IVersionProvider {
                 throw new CommandLine.ParameterException(cmd, "Missing required subcommand.");
             }
 
-            if (configFile != null) {
-                config = configManager.load(configFile);
-            }
-
             if (usePlugins != null) {
                 for (Plugin plugin : pluginManager.getPlugins()) {
                     plugin.setEnabled(usePlugins.getOrDefault(plugin.getClass().getName(), plugin.isEnabled()));
@@ -173,12 +169,17 @@ public class Launcher implements Command, CommandLine.IVersionProvider {
                 Class<?> type = command.getClass();
                 do {
                     for (Field field : type.getDeclaredFields()) {
+                        field.setAccessible(true);
                         if (Option.class.isAssignableFrom(field.getType())) {
-                            field.setAccessible(true);
                             Option option = (Option) field.get(command);
                             if (option != null) {
                                 option.preprocess(commandLine);
                             }
+                        }
+
+                        if (field.isAnnotationPresent(ConfigOption.class)
+                                && Config.class.isAssignableFrom(field.getType())) {
+                            field.set(command, config);
                         }
                     }
                 } while ((type = type.getSuperclass()) != Object.class);
@@ -224,11 +225,15 @@ public class Launcher implements Command, CommandLine.IVersionProvider {
         initializeLogging();
         logger.info("Starting " + CliConstants.APP_NAME + ", " + "version " + CliConstants.APP_VERSION + ".");
 
-        loadPlugins();
-
         if (pidFile != null) {
             createPidFile();
         }
+
+        if (configFile != null) {
+            loadConfig();
+        }
+
+        loadPlugins();
 
         logger.info("Executing '" + subCommandName + "' command.");
         return CommandLine.ExitCode.OK;
@@ -258,6 +263,24 @@ public class Launcher implements Command, CommandLine.IVersionProvider {
         }
     }
 
+    private void createPidFile() throws ExecutionException {
+        try {
+            logger.debug("Creating PID file at " + pidFile.toAbsolutePath() + ".");
+            PidFile.create(pidFile, true);
+        } catch (IOException e) {
+            throw new ExecutionException("Failed to create PID file.", e);
+        }
+    }
+
+    private void loadConfig() throws ExecutionException {
+        logger.info("Loading configuration from file " + configFile + "...");
+        try {
+            config.putAll(ConfigManager.newInstance().read(configFile, Config.class, Config::new));
+        } catch (Exception e) {
+            throw new ExecutionException("Failed to load config file.", e);
+        }
+    }
+
     private void loadPlugins() throws ExecutionException {
         logger.info("Loading plugins...");
         if (!pluginManager.hasExceptions()) {
@@ -275,15 +298,6 @@ public class Launcher implements Command, CommandLine.IVersionProvider {
                     .forEach(e -> logger.error(e.getMessage(), e.getCause()));
 
             throw new ExecutionException("Failed to load plugins.");
-        }
-    }
-
-    private void createPidFile() throws ExecutionException {
-        try {
-            logger.debug("Creating PID file at " + pidFile.toAbsolutePath() + ".");
-            PidFile.create(pidFile, true);
-        } catch (IOException e) {
-            throw new ExecutionException("Failed to create PID file.", e);
         }
     }
 
@@ -361,10 +375,6 @@ public class Launcher implements Command, CommandLine.IVersionProvider {
         LogLevel(Level level) {
             this.level = level;
         }
-    }
-
-    public Config getConfig() {
-        return config;
     }
 
     @Override

--- a/citydb-cli/src/main/java/org/citydb/cli/command/Command.java
+++ b/citydb-cli/src/main/java/org/citydb/cli/command/Command.java
@@ -33,6 +33,10 @@ public interface Command extends Callable<Integer> {
     default void preprocess(CommandLine commandLine) throws Exception {}
     default void registerSubcommands(CommandLine commandLine, PluginManager pluginManager) throws Exception {}
 
+    static boolean hasMatchedOption(String name, CommandLine.Model.CommandSpec commandSpec) {
+        return commandSpec.commandLine().getParseResult().hasMatchedOption(name);
+    }
+
     static void addSubcommand(Command command, CommandLine commandLine, PluginManager pluginManager) throws Exception {
         CommandLine subcommandLine = new CommandLine(command);
         command.registerSubcommands(subcommandLine, pluginManager);

--- a/citydb-cli/src/main/java/org/citydb/cli/deleter/DeleteCommand.java
+++ b/citydb-cli/src/main/java/org/citydb/cli/deleter/DeleteCommand.java
@@ -24,12 +24,14 @@ package org.citydb.cli.deleter;
 import org.apache.logging.log4j.Logger;
 import org.citydb.cli.ExecutionException;
 import org.citydb.cli.command.Command;
+import org.citydb.cli.option.ConfigOption;
 import org.citydb.cli.option.DatabaseOptions;
 import org.citydb.cli.option.IndexOption;
 import org.citydb.cli.option.MetadataOptions;
 import org.citydb.cli.util.CommandHelper;
 import org.citydb.cli.util.QueryExecutor;
 import org.citydb.cli.util.QueryResult;
+import org.citydb.config.Config;
 import org.citydb.database.DatabaseManager;
 import org.citydb.database.adapter.DatabaseAdapter;
 import org.citydb.logging.LoggerManager;
@@ -70,6 +72,12 @@ public class DeleteCommand implements Command {
             heading = "Database connection options:%n")
     private DatabaseOptions databaseOptions;
 
+    @CommandLine.Spec
+    private CommandLine.Model.CommandSpec commandSpec;
+
+    @ConfigOption
+    private Config config;
+
     private final Logger logger = LoggerManager.getInstance().getLogger();
     private final CommandHelper helper = CommandHelper.of(logger);
     private final Object lock = new Object();
@@ -99,7 +107,7 @@ public class DeleteCommand implements Command {
         try  {
             logger.info("Querying features matching the request...");
             try (QueryResult result = executor.executeQuery(getQuery(databaseManager.getAdapter()))) {
-                deleter.startSession(databaseManager.getAdapter(), getExportOptions());
+                deleter.startSession(databaseManager.getAdapter(), getDeleteOptions());
                 while (shouldRun && result.hasNext()) {
                     long id = result.getId();
                     int objectClassId = result.getObjectClassId();
@@ -166,17 +174,32 @@ public class DeleteCommand implements Command {
         return select;
     }
 
-    private DeleteOptions getExportOptions() {
-        DeleteOptions options = DeleteOptions.defaults()
-                .setMode(mode == Mode.terminate ? DeleteMode.TERMINATE : DeleteMode.DELETE);
-
-        if (metadataOptions != null) {
-            options.setLineage(metadataOptions.getLineage())
-                    .setUpdatingPerson(metadataOptions.getUpdatingPerson())
-                    .setReasonForUpdate(metadataOptions.getReasonForUpdate());
+    private DeleteOptions getDeleteOptions() {
+        DeleteOptions deleteOptions = config.get(DeleteOptions.class);
+        if (deleteOptions != null) {
+            if (Command.hasMatchedOption("--delete-mode", commandSpec)) {
+                deleteOptions.setMode(mode == Mode.terminate ? DeleteMode.TERMINATE : DeleteMode.DELETE);
+            }
+        } else {
+            deleteOptions = config.setAndGet(new DeleteOptions())
+                    .setMode(mode == Mode.terminate ? DeleteMode.TERMINATE : DeleteMode.DELETE);
         }
 
-        return options;
+        if (metadataOptions != null) {
+            if (metadataOptions.getLineage() != null) {
+                deleteOptions.setLineage(metadataOptions.getLineage());
+            }
+
+            if (metadataOptions.getUpdatingPerson() != null) {
+                deleteOptions.setUpdatingPerson(metadataOptions.getUpdatingPerson());
+            }
+
+            if (metadataOptions.getReasonForUpdate() != null) {
+                deleteOptions.setReasonForUpdate(metadataOptions.getReasonForUpdate());
+            }
+        }
+
+        return deleteOptions;
     }
 
     private void abort(long id, Throwable e) {

--- a/citydb-cli/src/main/java/org/citydb/cli/exporter/cityjson/CityJSONExportCommand.java
+++ b/citydb-cli/src/main/java/org/citydb/cli/exporter/cityjson/CityJSONExportCommand.java
@@ -22,12 +22,16 @@
 package org.citydb.cli.exporter.cityjson;
 
 import org.citydb.cli.ExecutionException;
+import org.citydb.cli.command.Command;
 import org.citydb.cli.exporter.ExportController;
 import org.citydb.database.DatabaseManager;
 import org.citydb.io.IOAdapter;
 import org.citydb.io.IOAdapterManager;
 import org.citydb.io.citygml.CityJSONAdapter;
 import org.citydb.io.citygml.writer.CityJSONFormatOptions;
+import org.citydb.io.writer.WriteOptions;
+import org.citydb.io.writer.option.OutputFormatOptions;
+import org.citydb.model.geometry.ImplicitGeometry;
 import org.citydb.operation.exporter.Exporter;
 import org.citygml4j.cityjson.adapter.appearance.serializer.AppearanceSerializer;
 import org.citygml4j.cityjson.adapter.geometry.serializer.GeometrySerializer;
@@ -37,6 +41,8 @@ import picocli.CommandLine;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.util.IdentityHashMap;
+import java.util.Map;
 
 @CommandLine.Command(
         name = "cityjson",
@@ -53,11 +59,11 @@ public class CityJSONExportCommand extends ExportController {
 
     @CommandLine.Option(names = "--pretty-print",
             description = "Format and indent output file.")
-    private boolean prettyPrint;
+    private Boolean prettyPrint;
 
     @CommandLine.Option(names = "--html-safe",
             description = "Write JSON that is safe to embed into HTML.")
-    private boolean htmlSafe;
+    private Boolean htmlSafe;
 
     @CommandLine.Option(names = "--vertex-precision", paramLabel = "<digits>",
             description = "Number of decimal places to keep for geometry vertices (default: ${DEFAULT-VALUE}).")
@@ -78,7 +84,7 @@ public class CityJSONExportCommand extends ExportController {
 
     @CommandLine.Option(names = "--replace-templates",
             description = "Replace template geometries with real coordinates.")
-    private boolean replaceTemplateGeometries;
+    private Boolean replaceTemplateGeometries;
 
     @CommandLine.Option(names = "--no-material-defaults", negatable = true, defaultValue = "true",
             description = "Use CityGML default values for material properties (default: ${DEFAULT-VALUE}).")
@@ -88,7 +94,10 @@ public class CityJSONExportCommand extends ExportController {
             heading = "Upgrade options for CityGML 2.0 and 1.0:%n")
     private UpgradeOptions upgradeOptions;
 
-    private final CityJSONFormatOptions formatOptions = new CityJSONFormatOptions();
+    @CommandLine.Spec
+    private CommandLine.Model.CommandSpec commandSpec;
+
+    private final Map<ImplicitGeometry, String> globalTemplates = new IdentityHashMap<>();
     private volatile boolean shouldRun = true;
     private Throwable exception;
 
@@ -98,21 +107,66 @@ public class CityJSONExportCommand extends ExportController {
     }
 
     @Override
-    protected Object getFormatOptions() {
-        formatOptions
-                .setVersion(version)
-                .setJsonLines(jsonLines)
-                .setPrettyPrint(prettyPrint)
-                .setHtmlSafe(htmlSafe)
-                .setVertexPrecision(vertexPrecision)
-                .setTemplatePrecision(templatePrecision)
-                .setTextureVertexPrecision(textureVertexPrecision)
-                .setTransformCoordinates(transformCoordinates)
-                .setReplaceTemplateGeometries(replaceTemplateGeometries)
-                .setUseMaterialDefaults(useMaterialDefaults);
+    protected OutputFormatOptions getFormatOptions(WriteOptions writeOptions) {
+        CityJSONFormatOptions formatOptions = writeOptions.getFormatOptions().get(CityJSONFormatOptions.class);
+        if (formatOptions != null) {
+            if (Command.hasMatchedOption("--cityjson-version", commandSpec)) {
+                formatOptions.setVersion(version);
+            }
 
-        if (upgradeOptions != null) {
-            formatOptions.setUseLod4AsLod3(upgradeOptions.isUseLod4AsLod3());
+            if (Command.hasMatchedOption("--no-json-lines", commandSpec)) {
+                formatOptions.setJsonLines(jsonLines);
+            }
+
+            if (Command.hasMatchedOption("--vertex-precision", commandSpec)) {
+                formatOptions.setVertexPrecision(vertexPrecision);
+            }
+
+            if (Command.hasMatchedOption("--template-precision", commandSpec)) {
+                formatOptions.setTemplatePrecision(templatePrecision);
+            }
+
+            if (Command.hasMatchedOption("--texture-vertex-precision", commandSpec)) {
+                formatOptions.setTextureVertexPrecision(textureVertexPrecision);
+            }
+
+            if (Command.hasMatchedOption("--no-transform-coordinates", commandSpec)) {
+                formatOptions.setTransformCoordinates(transformCoordinates);
+            }
+
+            if (Command.hasMatchedOption("--no-material-defaults", commandSpec)) {
+                formatOptions.setUseMaterialDefaults(useMaterialDefaults);
+            }
+        } else {
+            formatOptions = writeOptions.getFormatOptions().setAndGet(new CityJSONFormatOptions())
+                    .setVersion(version)
+                    .setJsonLines(jsonLines)
+                    .setVertexPrecision(vertexPrecision)
+                    .setTemplatePrecision(templatePrecision)
+                    .setTextureVertexPrecision(textureVertexPrecision)
+                    .setTransformCoordinates(transformCoordinates)
+                    .setUseMaterialDefaults(useMaterialDefaults);
+        }
+
+        if (prettyPrint != null) {
+            formatOptions.setPrettyPrint(prettyPrint);
+        }
+
+        if (htmlSafe != null) {
+            formatOptions.setHtmlSafe(htmlSafe);
+        }
+
+        if (replaceTemplateGeometries != null) {
+            formatOptions.setReplaceTemplateGeometries(replaceTemplateGeometries);
+        }
+
+        if (upgradeOptions != null && upgradeOptions.getUseLod4AsLod3() != null) {
+            formatOptions.setUseLod4AsLod3(upgradeOptions.getUseLod4AsLod3());
+        }
+
+        if (!globalTemplates.isEmpty()) {
+            globalTemplates.forEach(formatOptions::addGlobalTemplate);
+            globalTemplates.clear();
         }
 
         return formatOptions;
@@ -135,7 +189,7 @@ public class CityJSONExportCommand extends ExportController {
 
                     exporter.exportImplicitGeometry(id).whenComplete((implicitGeometry, e) -> {
                         if (implicitGeometry != null) {
-                            formatOptions.addGlobalTemplate(implicitGeometry, lod);
+                            globalTemplates.put(implicitGeometry, lod);
                         } else {
                             shouldRun = false;
                             exception = e;
@@ -160,7 +214,7 @@ public class CityJSONExportCommand extends ExportController {
             jsonLines = false;
         }
 
-        if (jsonLines && prettyPrint) {
+        if (jsonLines && prettyPrint != null) {
             throw new CommandLine.ParameterException(commandLine,
                     "Error: --json-lines and --pretty-print are mutually exclusive (specify only one)");
         }

--- a/citydb-cli/src/main/java/org/citydb/cli/exporter/cityjson/UpgradeOptions.java
+++ b/citydb-cli/src/main/java/org/citydb/cli/exporter/cityjson/UpgradeOptions.java
@@ -27,9 +27,9 @@ import picocli.CommandLine;
 public class UpgradeOptions implements Option {
     @CommandLine.Option(names = "--use-lod4-as-lod3",
             description = "Use LoD4 as LoD3, replacing an existing LoD3.")
-    private boolean useLod4AsLod3;
+    private Boolean useLod4AsLod3;
 
-    public boolean isUseLod4AsLod3() {
+    public Boolean getUseLod4AsLod3() {
         return useLod4AsLod3;
     }
 }

--- a/citydb-cli/src/main/java/org/citydb/cli/importer/citygml/CityGMLImportCommand.java
+++ b/citydb-cli/src/main/java/org/citydb/cli/importer/citygml/CityGMLImportCommand.java
@@ -22,10 +22,13 @@
 package org.citydb.cli.importer.citygml;
 
 import org.citydb.cli.importer.ImportController;
+import org.citydb.cli.option.UpgradeOptions;
 import org.citydb.io.IOAdapter;
 import org.citydb.io.IOAdapterManager;
 import org.citydb.io.citygml.CityGMLAdapter;
 import org.citydb.io.citygml.reader.CityGMLFormatOptions;
+import org.citydb.io.reader.ReadOptions;
+import org.citydb.io.reader.option.InputFormatOptions;
 import picocli.CommandLine;
 
 @CommandLine.Command(
@@ -34,7 +37,7 @@ import picocli.CommandLine;
 public class CityGMLImportCommand extends ImportController {
     @CommandLine.Option(names = "--import-xal-source",
             description = "Import XML snippets of xAL address elements.")
-    protected boolean importXALSource;
+    protected Boolean importXALSource;
 
     @CommandLine.ArgGroup(exclusive = false,
             heading = "Upgrade options for CityGML 2.0 and 1.0:%n")
@@ -46,14 +49,26 @@ public class CityGMLImportCommand extends ImportController {
     }
 
     @Override
-    protected Object getFormatOptions() {
-        CityGMLFormatOptions formatOptions = new CityGMLFormatOptions()
-                .setImportXALSource(importXALSource);
+    protected InputFormatOptions getFormatOptions(ReadOptions readOptions) {
+        CityGMLFormatOptions formatOptions = readOptions.getFormatOptions()
+                .getOrCreate(CityGMLFormatOptions.class, CityGMLFormatOptions::new);
+
+        if (importXALSource != null) {
+            formatOptions.setImportXALSource(importXALSource);
+        }
 
         if (upgradeOptions != null) {
-            formatOptions.setUseLod4AsLod3(upgradeOptions.isUseLod4AsLod3())
-                    .setMapLod0RoofEdge(upgradeOptions.isMapLod0RoofEdge())
-                    .setMapLod1MultiSurfaces(upgradeOptions.isMapLod1MultiSurface());
+            if (upgradeOptions.getUseLod4AsLod3() != null) {
+                formatOptions.setUseLod4AsLod3(upgradeOptions.getUseLod4AsLod3());
+            }
+
+            if (upgradeOptions.getMapLod0RoofEdge() != null) {
+                formatOptions.setMapLod0RoofEdge(upgradeOptions.getMapLod0RoofEdge());
+            }
+
+            if (upgradeOptions.getMapLod1MultiSurface() != null) {
+                formatOptions.setMapLod1MultiSurfaces(upgradeOptions.getMapLod1MultiSurface());
+            }
         }
 
         return formatOptions;

--- a/citydb-cli/src/main/java/org/citydb/cli/importer/cityjson/CityJSONImportCommand.java
+++ b/citydb-cli/src/main/java/org/citydb/cli/importer/cityjson/CityJSONImportCommand.java
@@ -21,11 +21,14 @@
 
 package org.citydb.cli.importer.cityjson;
 
+import org.citydb.cli.command.Command;
 import org.citydb.cli.importer.ImportController;
 import org.citydb.io.IOAdapter;
 import org.citydb.io.IOAdapterManager;
 import org.citydb.io.citygml.CityJSONAdapter;
 import org.citydb.io.citygml.reader.CityJSONFormatOptions;
+import org.citydb.io.reader.ReadOptions;
+import org.citydb.io.reader.option.InputFormatOptions;
 import picocli.CommandLine;
 
 @CommandLine.Command(
@@ -37,14 +40,26 @@ public class CityJSONImportCommand extends ImportController {
                     "(default: ${DEFAULT-VALUE}).")
     private boolean mapUnknownObjects;
 
+    @CommandLine.Spec
+    private CommandLine.Model.CommandSpec commandSpec;
+
     @Override
     protected IOAdapter getIOAdapter(IOAdapterManager ioManager) {
         return ioManager.getAdapter(CityJSONAdapter.class);
     }
 
     @Override
-    protected Object getFormatOptions() {
-        return new CityJSONFormatOptions()
-                .setMapUnsupportedTypesToGenerics(mapUnknownObjects);
+    protected InputFormatOptions getFormatOptions(ReadOptions readOptions) {
+        CityJSONFormatOptions formatOptions = readOptions.getFormatOptions().get(CityJSONFormatOptions.class);
+        if (formatOptions != null) {
+            if (Command.hasMatchedOption("--no-map-unknown-objects", commandSpec)) {
+                formatOptions.setMapUnsupportedTypesToGenerics(mapUnknownObjects);
+            }
+        } else {
+            formatOptions = readOptions.getFormatOptions().setAndGet(new CityJSONFormatOptions())
+                    .setMapUnsupportedTypesToGenerics(mapUnknownObjects);
+        }
+
+        return formatOptions;
     }
 }

--- a/citydb-cli/src/main/java/org/citydb/cli/option/ConfigOption.java
+++ b/citydb-cli/src/main/java/org/citydb/cli/option/ConfigOption.java
@@ -19,21 +19,12 @@
  * limitations under the License.
  */
 
-package org.citydb.io.citygml.reader;
+package org.citydb.cli.option;
 
-import org.citydb.config.SerializableConfig;
-import org.citydb.io.reader.option.InputFormatOptions;
+import java.lang.annotation.*;
 
-@SerializableConfig(jsonField = "CityJSON")
-public class CityJSONFormatOptions implements InputFormatOptions {
-    private boolean mapUnsupportedTypesToGenerics = true;
-
-    public boolean isMapUnsupportedTypesToGenerics() {
-        return mapUnsupportedTypesToGenerics;
-    }
-
-    public CityJSONFormatOptions setMapUnsupportedTypesToGenerics(boolean mapUnsupportedTypesToGenerics) {
-        this.mapUnsupportedTypesToGenerics = mapUnsupportedTypesToGenerics;
-        return this;
-    }
+@Documented
+@Target(value = ElementType.FIELD)
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface ConfigOption {
 }

--- a/citydb-cli/src/main/java/org/citydb/cli/option/ThreadsOption.java
+++ b/citydb-cli/src/main/java/org/citydb/cli/option/ThreadsOption.java
@@ -26,10 +26,10 @@ import picocli.CommandLine;
 public class ThreadsOption implements Option {
     @CommandLine.Option(names = "--threads",
             description = "Number of threads to use for parallel processing.")
-    protected Integer threads;
+    private Integer threads;
 
-    public int getNumberOfThreads() {
-        return threads != null ? threads : 0;
+    public Integer getNumberOfThreads() {
+        return threads;
     }
 
     @Override

--- a/citydb-cli/src/main/java/org/citydb/cli/option/UpgradeOptions.java
+++ b/citydb-cli/src/main/java/org/citydb/cli/option/UpgradeOptions.java
@@ -19,33 +19,32 @@
  * limitations under the License.
  */
 
-package org.citydb.cli.importer.citygml;
+package org.citydb.cli.option;
 
-import org.citydb.cli.option.Option;
 import picocli.CommandLine;
 
 public class UpgradeOptions implements Option {
     @CommandLine.Option(names = "--use-lod4-as-lod3",
             description = "Use LoD4 as LoD3, replacing an existing LoD3.")
-    private boolean useLod4AsLod3;
+    private Boolean useLod4AsLod3;
 
     @CommandLine.Option(names = "--map-lod0-roof-edge",
             description = "Map LoD0 roof edges onto roof surfaces.")
-    private boolean mapLod0RoofEdge;
+    private Boolean mapLod0RoofEdge;
 
     @CommandLine.Option(names = "--map-lod1-surface",
             description = "Map LoD1 multi-surfaces onto generic thematic surfaces.")
-    private boolean mapLod1MultiSurface;
+    private Boolean mapLod1MultiSurface;
 
-    public boolean isUseLod4AsLod3() {
+    public Boolean getUseLod4AsLod3() {
         return useLod4AsLod3;
     }
 
-    public boolean isMapLod0RoofEdge() {
+    public Boolean getMapLod0RoofEdge() {
         return mapLod0RoofEdge;
     }
 
-    public boolean isMapLod1MultiSurface() {
+    public Boolean getMapLod1MultiSurface() {
         return mapLod1MultiSurface;
     }
 }

--- a/citydb-config/src/main/java/module-info.java
+++ b/citydb-config/src/main/java/module-info.java
@@ -1,7 +1,5 @@
 module org.citydb.config {
-    requires com.alibaba.fastjson2;
+    requires transitive com.alibaba.fastjson2;
 
     exports org.citydb.config;
-
-    opens org.citydb.config to com.alibaba.fastjson2;
 }

--- a/citydb-config/src/main/java/org/citydb/config/Config.java
+++ b/citydb-config/src/main/java/org/citydb/config/Config.java
@@ -21,49 +21,5 @@
 
 package org.citydb.config;
 
-import com.alibaba.fastjson2.JSON;
-import com.alibaba.fastjson2.JSONObject;
-import com.alibaba.fastjson2.annotation.JSONField;
-
-import java.util.HashMap;
-import java.util.Map;
-
-public class Config {
-    @JSONField(name = "config")
-    private Map<String, JSONObject> configs = new HashMap<>();
-
-    public Map<String, JSONObject> getConfigs() {
-        return configs;
-    }
-
-    public Config setConfig(String name, JSONObject config) {
-        configs.put(name, config);
-        return this;
-    }
-
-    public <T> T getConfig(String name, Class<T> type) throws ConfigException {
-        JSONObject options = configs.get(name);
-        if (options != null) {
-            return JSON.parseObject(options.toString(), type);
-        } else {
-            throw new ConfigException("Unsupported configuration type '" + type.getName() + "'.");
-        }
-    }
-
-    public <T> Config setConfig(String name, Object config) {
-        Object object = JSON.toJSON(config);
-        if (object instanceof JSONObject) {
-            configs.put(name, (JSONObject) JSON.toJSON(config));
-        }
-
-        return this;
-    }
-
-    public Config setConfigs(Map<String, JSONObject> configs) {
-        if (configs != null) {
-            this.configs = configs;
-        }
-
-        return this;
-    }
+public class Config extends ConfigObject<Object> {
 }

--- a/citydb-config/src/main/java/org/citydb/config/ConfigManager.java
+++ b/citydb-config/src/main/java/org/citydb/config/ConfigManager.java
@@ -28,38 +28,41 @@ import com.alibaba.fastjson2.JSONWriter;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 public class ConfigManager {
-    private static final ConfigManager instance = new ConfigManager();
 
     private ConfigManager() {
     }
 
-    public static ConfigManager getInstance() {
-        return instance;
+    public static ConfigManager newInstance() {
+        return new ConfigManager();
     }
 
-    public Config load(Path path) throws ConfigException {
-        Objects.requireNonNull(path, "The path must not be null.");
-
-        try (InputStream inStream = new BufferedInputStream(Files.newInputStream(path))) {
-            return JSON.parseObject(new String(inStream.readAllBytes()), Config.class);
-        } catch (IOException e) {
-            throw new ConfigException("Failed to read the config file " + path + ".", e);
+    public <T> T read(Path inputFile, Class<T> type) throws ConfigException, IOException {
+        Objects.requireNonNull(inputFile, "The input file must not be null.");
+        try (InputStream stream = new BufferedInputStream(Files.newInputStream(inputFile))) {
+            return JSON.parseObject(new String(stream.readAllBytes(), StandardCharsets.UTF_8), type);
         } catch (JSONException e) {
-            throw new ConfigException("Failed to parse the config file " + path + ".", e);
+            throw new ConfigException("Failed to parse config file " + inputFile + ".", e);
         }
     }
 
-    public void writeTo(Config config, Path target) throws ConfigException {
-        Objects.requireNonNull(target, "The target path must not be null.");
-        try {
-            Files.write(target, JSON.toJSONString(config, JSONWriter.Feature.PrettyFormat).getBytes());
-        } catch (IOException e) {
-            throw new ConfigException("Failed to write config file to " + target, e);
-        }
+    public <T> T read(Path inputFile, Class<T> type, Supplier<T> supplier) throws ConfigException, IOException {
+        T config = read(inputFile, type);
+        return config != null ? config : supplier.get();
+    }
+
+    public void write(Object config, Path outputFile) throws IOException {
+        Objects.requireNonNull(config, "The config object must not be null.");
+        outputFile = Objects.requireNonNull(outputFile, "The output file must not be null.")
+                .normalize()
+                .toAbsolutePath();
+
+        Files.writeString(outputFile, JSON.toJSONString(config, JSONWriter.Feature.PrettyFormat));
     }
 }

--- a/citydb-config/src/main/java/org/citydb/config/ConfigObject.java
+++ b/citydb-config/src/main/java/org/citydb/config/ConfigObject.java
@@ -1,0 +1,112 @@
+/*
+ * citydb-tool - Command-line tool for the 3D City Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2022-2023
+ * virtualcitysystems GmbH, Germany
+ * https://vc.systems/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.config;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+
+import java.util.LinkedHashMap;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class ConfigObject<T> extends LinkedHashMap<String, T> {
+
+    public <E extends T> E get(Class<E> type) {
+        return get(getName(type), type);
+    }
+
+    public <E extends T> E get(String name, Class<E> type) {
+        Object object = get(name);
+        if (type.isInstance(object)) {
+            return type.cast(object);
+        } else if (object instanceof JSONObject) {
+            E config = JSON.parseObject(object.toString(), type);
+            if (config != null) {
+                set(config);
+                return config;
+            }
+        }
+
+        return null;
+    }
+
+    public <E extends T> E getOrCreate(Class<E> type, Supplier<E> supplier) {
+        return getOrCreate(getName(type), type, supplier);
+    }
+
+    public <E extends T> E getOrCreate(String name, Class<E> type, Supplier<E> supplier) {
+        E config = get(name, type);
+        if (config == null) {
+            config = supplier.get();
+            put(name, config);
+        }
+
+        return config;
+    }
+
+    public ConfigObject<T> set(T config) {
+        return set(getName(config), config);
+    }
+
+    public ConfigObject<T> set(String name, T config) {
+        put(name, config);
+        return this;
+    }
+
+    public <E extends T> E setAndGet(E config) {
+        return setAndGet(getName(config), config);
+    }
+
+    public <E extends T> E setAndGet(String name, E config) {
+        put(name, config);
+        return config;
+    }
+
+    public <E extends T> boolean isPresent(Class<E> type) {
+        return isPresent(getName(type));
+    }
+
+    public boolean isPresent(String name) {
+        return containsKey(name);
+    }
+
+    public <E extends T> void ifPresent(Class<E> type, Consumer<E> action) {
+        ifPresent(getName(type), type, action);
+    }
+
+    public <E extends T> void ifPresent(String name, Class<E> type, Consumer<E> action) {
+        E config = get(name, type);
+        if (config != null) {
+            action.accept(config);
+        }
+    }
+
+    private String getName(Object config) {
+        return getName(config.getClass());
+    }
+
+    private String getName(Class<?> type) {
+        return type.isAnnotationPresent(SerializableConfig.class) ?
+                type.getAnnotation(SerializableConfig.class).jsonField() :
+                type.getName();
+    }
+}

--- a/citydb-config/src/main/java/org/citydb/config/SerializableConfig.java
+++ b/citydb-config/src/main/java/org/citydb/config/SerializableConfig.java
@@ -19,21 +19,13 @@
  * limitations under the License.
  */
 
-package org.citydb.io.citygml.reader;
+package org.citydb.config;
 
-import org.citydb.config.SerializableConfig;
-import org.citydb.io.reader.option.InputFormatOptions;
+import java.lang.annotation.*;
 
-@SerializableConfig(jsonField = "CityJSON")
-public class CityJSONFormatOptions implements InputFormatOptions {
-    private boolean mapUnsupportedTypesToGenerics = true;
-
-    public boolean isMapUnsupportedTypesToGenerics() {
-        return mapUnsupportedTypesToGenerics;
-    }
-
-    public CityJSONFormatOptions setMapUnsupportedTypesToGenerics(boolean mapUnsupportedTypesToGenerics) {
-        this.mapUnsupportedTypesToGenerics = mapUnsupportedTypesToGenerics;
-        return this;
-    }
+@Documented
+@Target(value = ElementType.TYPE)
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface SerializableConfig {
+    String jsonField();
 }

--- a/citydb-io-citygml/src/main/java/org/citydb/io/citygml/reader/CityGMLFormatOptions.java
+++ b/citydb-io-citygml/src/main/java/org/citydb/io/citygml/reader/CityGMLFormatOptions.java
@@ -21,7 +21,11 @@
 
 package org.citydb.io.citygml.reader;
 
-public class CityGMLFormatOptions {
+import org.citydb.config.SerializableConfig;
+import org.citydb.io.reader.option.InputFormatOptions;
+
+@SerializableConfig(jsonField = "CityGML")
+public class CityGMLFormatOptions implements InputFormatOptions {
     private boolean resolveGeometryReferences = true;
     private boolean resolveCrossLodReferences = true;
     private boolean createCityObjectRelations = true;

--- a/citydb-io-citygml/src/main/java/org/citydb/io/citygml/reader/CityGMLReader.java
+++ b/citydb-io-citygml/src/main/java/org/citydb/io/citygml/reader/CityGMLReader.java
@@ -32,7 +32,6 @@ import org.citydb.io.citygml.reader.util.FileMetadata;
 import org.citydb.io.reader.FeatureReader;
 import org.citydb.io.reader.ReadException;
 import org.citydb.io.reader.ReadOptions;
-import org.citydb.io.util.FormatOptions;
 import org.citydb.logging.LoggerManager;
 import org.citydb.model.feature.Feature;
 import org.citygml4j.core.model.cityobjectgroup.CityObjectGroup;
@@ -72,8 +71,7 @@ public class CityGMLReader implements FeatureReader {
         this.options = Objects.requireNonNull(options, "The reader options must not be null.");
         factory.setReadOptions(options);
 
-        formatOptions = FormatOptions.parseElseGet(options.getFormatOptions(),
-                CityGMLFormatOptions.class, CityGMLFormatOptions::new);
+        formatOptions = options.getFormatOptions().getOrCreate(CityGMLFormatOptions.class, CityGMLFormatOptions::new);
 
         try {
             store = PersistentMapStore.newInstance();

--- a/citydb-io-citygml/src/main/java/org/citydb/io/citygml/reader/CityJSONReader.java
+++ b/citydb-io-citygml/src/main/java/org/citydb/io/citygml/reader/CityJSONReader.java
@@ -31,7 +31,6 @@ import org.citydb.io.citygml.reader.util.FileMetadata;
 import org.citydb.io.reader.FeatureReader;
 import org.citydb.io.reader.ReadException;
 import org.citydb.io.reader.ReadOptions;
-import org.citydb.io.util.FormatOptions;
 import org.citydb.logging.LoggerManager;
 import org.citydb.model.feature.Feature;
 import org.citygml4j.cityjson.CityJSONContext;
@@ -77,8 +76,7 @@ public class CityJSONReader implements FeatureReader {
 
         factory = CityJSONReaderFactory.newInstance(cityJSONContext)
                 .setReadOptions(options)
-                .setFormatOptions(FormatOptions.parseElseGet(options.getFormatOptions(),
-                        CityJSONFormatOptions.class, CityJSONFormatOptions::new));
+                .setFormatOptions(options.getFormatOptions().get(CityJSONFormatOptions.class));
 
         isInitialized = true;
         shouldRun = true;

--- a/citydb-io-citygml/src/main/java/org/citydb/io/citygml/writer/CityGMLFormatOptions.java
+++ b/citydb-io-citygml/src/main/java/org/citydb/io/citygml/writer/CityGMLFormatOptions.java
@@ -23,10 +23,13 @@ package org.citydb.io.citygml.writer;
 
 import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.annotation.JSONField;
+import org.citydb.config.SerializableConfig;
 import org.citydb.io.citygml.writer.options.AddressMode;
+import org.citydb.io.writer.option.OutputFormatOptions;
 import org.citygml4j.core.model.CityGMLVersion;
 
-public class CityGMLFormatOptions {
+@SerializableConfig(jsonField = "CityGML")
+public class CityGMLFormatOptions implements OutputFormatOptions {
     @JSONField(serializeFeatures = JSONWriter.Feature.WriteEnumUsingToString)
     private CityGMLVersion version;
     private boolean prettyPrint = true;

--- a/citydb-io-citygml/src/main/java/org/citydb/io/citygml/writer/CityGMLWriter.java
+++ b/citydb-io-citygml/src/main/java/org/citydb/io/citygml/writer/CityGMLWriter.java
@@ -28,7 +28,6 @@ import org.citydb.core.concurrent.ExecutorHelper;
 import org.citydb.core.file.OutputFile;
 import org.citydb.io.citygml.CityGMLAdapterContext;
 import org.citydb.io.citygml.writer.util.GlobalFeatureWriter;
-import org.citydb.io.util.FormatOptions;
 import org.citydb.io.writer.FeatureWriter;
 import org.citydb.io.writer.WriteException;
 import org.citydb.io.writer.WriteOptions;
@@ -62,8 +61,8 @@ public class CityGMLWriter implements FeatureWriter, GlobalFeatureWriter {
 
     @Override
     public void initialize(OutputFile file, WriteOptions options) throws WriteException {
-        CityGMLFormatOptions formatOptions = FormatOptions.parseElseGet(options.getFormatOptions(),
-                CityGMLFormatOptions.class, CityGMLFormatOptions::new);
+        CityGMLFormatOptions formatOptions = options.getFormatOptions()
+                .getOrCreate(CityGMLFormatOptions.class, CityGMLFormatOptions::new);
 
         writer = CityGMLWriterFactory.newInstance(context.getCityGMLContext(), options, formatOptions)
                 .createWriter(file);

--- a/citydb-io-citygml/src/main/java/org/citydb/io/citygml/writer/CityJSONFormatOptions.java
+++ b/citydb-io-citygml/src/main/java/org/citydb/io/citygml/writer/CityJSONFormatOptions.java
@@ -23,6 +23,8 @@ package org.citydb.io.citygml.writer;
 
 import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.annotation.JSONField;
+import org.citydb.config.SerializableConfig;
+import org.citydb.io.writer.option.OutputFormatOptions;
 import org.citydb.model.geometry.ImplicitGeometry;
 import org.citygml4j.cityjson.adapter.appearance.serializer.AppearanceSerializer;
 import org.citygml4j.cityjson.adapter.geometry.serializer.GeometrySerializer;
@@ -33,7 +35,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class CityJSONFormatOptions {
+@SerializableConfig(jsonField = "CityJSON")
+public class CityJSONFormatOptions implements OutputFormatOptions {
     public static final String TEMPLATE_LOD_PROPERTY = "lod";
 
     @JSONField(serializeFeatures = JSONWriter.Feature.WriteEnumUsingToString)

--- a/citydb-io-citygml/src/main/java/org/citydb/io/citygml/writer/CityJSONWriter.java
+++ b/citydb-io-citygml/src/main/java/org/citydb/io/citygml/writer/CityJSONWriter.java
@@ -28,7 +28,6 @@ import org.citydb.core.concurrent.ExecutorHelper;
 import org.citydb.core.file.OutputFile;
 import org.citydb.io.citygml.CityGMLAdapterContext;
 import org.citydb.io.citygml.writer.util.GlobalFeatureWriter;
-import org.citydb.io.util.FormatOptions;
 import org.citydb.io.writer.FeatureWriter;
 import org.citydb.io.writer.WriteException;
 import org.citydb.io.writer.WriteOptions;
@@ -70,8 +69,8 @@ public class CityJSONWriter implements FeatureWriter, GlobalFeatureWriter {
 
     @Override
     public void initialize(OutputFile file, WriteOptions options) throws WriteException {
-        CityJSONFormatOptions formatOptions = FormatOptions.parseElseGet(options.getFormatOptions(),
-                CityJSONFormatOptions.class, CityJSONFormatOptions::new);
+        CityJSONFormatOptions formatOptions = options.getFormatOptions()
+                .getOrCreate(CityJSONFormatOptions.class, CityJSONFormatOptions::new);
 
         writer = CityJSONWriterFactory.newInstance(cityJSONContext, options, formatOptions)
                 .createWriter(file);

--- a/citydb-io/build.gradle
+++ b/citydb-io/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    api project(':citydb-config')
     api project(':citydb-core')
     api project(':citydb-model')
 }

--- a/citydb-io/src/main/java/module-info.java
+++ b/citydb-io/src/main/java/module-info.java
@@ -1,5 +1,5 @@
-@SuppressWarnings("requires-transitive-automatic")
 module org.citydb.io {
+    requires transitive org.citydb.config;
     requires transitive org.citydb.core;
     requires transitive org.citydb.model;
     requires java.sql;
@@ -8,8 +8,9 @@ module org.citydb.io {
 
     exports org.citydb.io;
     exports org.citydb.io.reader;
+    exports org.citydb.io.reader.option;
     exports org.citydb.io.util;
     exports org.citydb.io.validator;
     exports org.citydb.io.writer;
-    exports org.citydb.io.writer.options;
+    exports org.citydb.io.writer.option;
 }

--- a/citydb-io/src/main/java/org/citydb/io/reader/ReadOptions.java
+++ b/citydb-io/src/main/java/org/citydb/io/reader/ReadOptions.java
@@ -21,19 +21,17 @@
 
 package org.citydb.io.reader;
 
+import org.citydb.config.ConfigObject;
+import org.citydb.config.SerializableConfig;
+import org.citydb.io.reader.option.InputFormatOptions;
+
+@SerializableConfig(jsonField = "readOptions")
 public class ReadOptions {
     private boolean failFast;
     private int numberOfThreads;
     private String encoding;
     private boolean computeEnvelopes;
-    private Object formatOptions;
-
-    private ReadOptions() {
-    }
-
-    public static ReadOptions defaults() {
-        return new ReadOptions();
-    }
+    private ConfigObject<InputFormatOptions> formatOptions;
 
     public boolean isFailFast() {
         return failFast;
@@ -74,11 +72,15 @@ public class ReadOptions {
         return this;
     }
 
-    public Object getFormatOptions() {
+    public ConfigObject<InputFormatOptions> getFormatOptions() {
+        if (formatOptions == null) {
+            formatOptions = new ConfigObject<>();
+        }
+
         return formatOptions;
     }
 
-    public ReadOptions setFormatOptions(Object formatOptions) {
+    public ReadOptions setFormatOptions(ConfigObject<InputFormatOptions> formatOptions) {
         this.formatOptions = formatOptions;
         return this;
     }

--- a/citydb-io/src/main/java/org/citydb/io/reader/option/InputFormatOptions.java
+++ b/citydb-io/src/main/java/org/citydb/io/reader/option/InputFormatOptions.java
@@ -19,21 +19,7 @@
  * limitations under the License.
  */
 
-package org.citydb.io.citygml.reader;
+package org.citydb.io.reader.option;
 
-import org.citydb.config.SerializableConfig;
-import org.citydb.io.reader.option.InputFormatOptions;
-
-@SerializableConfig(jsonField = "CityJSON")
-public class CityJSONFormatOptions implements InputFormatOptions {
-    private boolean mapUnsupportedTypesToGenerics = true;
-
-    public boolean isMapUnsupportedTypesToGenerics() {
-        return mapUnsupportedTypesToGenerics;
-    }
-
-    public CityJSONFormatOptions setMapUnsupportedTypesToGenerics(boolean mapUnsupportedTypesToGenerics) {
-        this.mapUnsupportedTypesToGenerics = mapUnsupportedTypesToGenerics;
-        return this;
-    }
+public interface InputFormatOptions {
 }

--- a/citydb-io/src/main/java/org/citydb/io/writer/WriteOptions.java
+++ b/citydb-io/src/main/java/org/citydb/io/writer/WriteOptions.java
@@ -21,21 +21,18 @@
 
 package org.citydb.io.writer;
 
-import org.citydb.io.writer.options.SpatialReference;
+import org.citydb.config.ConfigObject;
+import org.citydb.config.SerializableConfig;
+import org.citydb.io.writer.option.OutputFormatOptions;
+import org.citydb.io.writer.option.SpatialReference;
 
+@SerializableConfig(jsonField = "writeOptions")
 public class WriteOptions {
     private boolean failFast;
     private int numberOfThreads;
     private String encoding;
     private SpatialReference spatialReference;
-    private Object formatOptions;
-
-    private WriteOptions() {
-    }
-
-    public static WriteOptions defaults() {
-        return new WriteOptions();
-    }
+    private ConfigObject<OutputFormatOptions> formatOptions;
 
     public boolean isFailFast() {
         return failFast;
@@ -76,11 +73,15 @@ public class WriteOptions {
         return this;
     }
 
-    public Object getFormatOptions() {
+    public ConfigObject<OutputFormatOptions> getFormatOptions() {
+        if (formatOptions == null) {
+            formatOptions = new ConfigObject<>();
+        }
+
         return formatOptions;
     }
 
-    public WriteOptions setFormatOptions(Object formatOptions) {
+    public WriteOptions setFormatOptions(ConfigObject<OutputFormatOptions> formatOptions) {
         this.formatOptions = formatOptions;
         return this;
     }

--- a/citydb-io/src/main/java/org/citydb/io/writer/option/OutputFormatOptions.java
+++ b/citydb-io/src/main/java/org/citydb/io/writer/option/OutputFormatOptions.java
@@ -19,30 +19,7 @@
  * limitations under the License.
  */
 
-package org.citydb.io.util;
+package org.citydb.io.writer.option;
 
-import com.alibaba.fastjson2.JSON;
-
-import java.util.function.Supplier;
-
-public class FormatOptions {
-
-    public static <T> T parse(Object options, Class<T> type) {
-        if (type.isInstance(options)) {
-            return type.cast(options);
-        } else if (options instanceof String str) {
-            try {
-                return JSON.parseObject(str, type);
-            } catch (Exception e) {
-                //
-            }
-        }
-
-        return null;
-    }
-
-    public static <T> T parseElseGet(Object options, Class<T> type, Supplier<T> supplier) {
-        T result = parse(options, type);
-        return result != null ? result : supplier.get();
-    }
+public interface OutputFormatOptions {
 }

--- a/citydb-io/src/main/java/org/citydb/io/writer/option/SpatialReference.java
+++ b/citydb-io/src/main/java/org/citydb/io/writer/option/SpatialReference.java
@@ -19,25 +19,31 @@
  * limitations under the License.
  */
 
-package org.citydb.io.writer.options;
+package org.citydb.io.writer.option;
+
+import com.alibaba.fastjson2.annotation.JSONField;
 
 public class SpatialReference {
     private int srid;
     private String uri;
 
+    @JSONField(name = "srid")
     public int getSRID() {
         return srid;
     }
 
+    @JSONField(name = "srid")
     public SpatialReference setSRID(int srid) {
         this.srid = srid;
         return this;
     }
 
+    @JSONField(name = "uri")
     public String getURI() {
         return uri;
     }
 
+    @JSONField(name = "uri")
     public SpatialReference setURI(String uri) {
         this.uri = uri;
         return this;

--- a/citydb-operation/build.gradle
+++ b/citydb-operation/build.gradle
@@ -1,3 +1,4 @@
 dependencies {
+    implementation project(':citydb-config')
     api project(':citydb-database')
 }

--- a/citydb-operation/src/main/java/module-info.java
+++ b/citydb-operation/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module org.citydb.operation {
+    requires org.citydb.config;
     requires transitive org.citydb.database;
 
     exports org.citydb.operation.deleter;

--- a/citydb-operation/src/main/java/org/citydb/operation/deleter/DeleteOptions.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/deleter/DeleteOptions.java
@@ -21,24 +21,22 @@
 
 package org.citydb.operation.deleter;
 
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.annotation.JSONField;
+import org.citydb.config.SerializableConfig;
 import org.citydb.operation.deleter.options.DeleteMode;
 
 import java.time.OffsetDateTime;
 
+@SerializableConfig(jsonField = "deleteOptions")
 public class DeleteOptions {
     private int numberOfThreads;
+    @JSONField(serializeFeatures = JSONWriter.Feature.WriteEnumUsingToString)
     private DeleteMode mode;
     private String updatingPerson;
     private String reasonForUpdate;
     private String lineage;
     private OffsetDateTime terminationDate;
-
-    private DeleteOptions() {
-    }
-
-    public static DeleteOptions defaults() {
-        return new DeleteOptions();
-    }
 
     public int getNumberOfThreads() {
         return numberOfThreads;

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/ExportOptions.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/ExportOptions.java
@@ -22,6 +22,7 @@
 package org.citydb.operation.exporter;
 
 import com.alibaba.fastjson2.annotation.JSONField;
+import org.citydb.config.SerializableConfig;
 import org.citydb.core.concurrent.LazyInitializer;
 import org.citydb.core.file.OutputFile;
 import org.citydb.core.file.output.RegularOutputFile;
@@ -30,6 +31,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+@SerializableConfig(jsonField = "exportOptions")
 public class ExportOptions {
     private final LazyInitializer<OutputFile, IOException> tempOutputFile = LazyInitializer.of(
             () -> new RegularOutputFile(Files.createTempDirectory("citydb-").resolve("output.tmp")));
@@ -38,13 +40,6 @@ public class ExportOptions {
     private OutputFile outputFile;
     private int numberOfThreads;
     private int numberOfTextureBuckets;
-
-    private ExportOptions() {
-    }
-
-    public static ExportOptions defaults() {
-        return new ExportOptions();
-    }
 
     public OutputFile getOutputFile() {
         if (outputFile == null) {

--- a/citydb-operation/src/main/java/org/citydb/operation/importer/ImportOptions.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/importer/ImportOptions.java
@@ -21,16 +21,12 @@
 
 package org.citydb.operation.importer;
 
+import org.citydb.config.SerializableConfig;
+
+@SerializableConfig(jsonField = "importOptions")
 public class ImportOptions {
     private int numberOfThreads;
     private int batchSize = 20;
-
-    private ImportOptions() {
-    }
-
-    public static ImportOptions defaults() {
-        return new ImportOptions();
-    }
 
     public int getNumberOfThreads() {
         return numberOfThreads;

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 rootProject.name = 'citydb-tool'
 include 'citydb-cli'
+include 'citydb-config'
 include 'citydb-core'
 include 'citydb-database'
 include 'citydb-database-postgres'
@@ -12,4 +13,3 @@ include 'citydb-logging'
 include 'citydb-model'
 include 'citydb-operation'
 include 'citydb-plugin'
-include 'citydb-config'


### PR DESCRIPTION
This PR integrates the new config module into all other modules and applies some minor changes to the config module.

Summary of changes:
- Use UTF-8 when reading/writing JSON config files
- Added `ConfigObject` which can be used as generic container for module-specific config classes (e.g., to manage format options in `ReadOptions` and `WriteOptions`)
- Added `@SerializableConfig` annotation to confgure the JSON key for config classes
- Adapted all config classes in the existing modules to use the new config module
- Added `@ConfigOption` annotation to inject a `Config` object into the CLI commands
- Adapted all CLI commands to consider the options from a config file provided through the new `--config-file` parameter. The following rules are applied:
  1. Settings provided through command-line parameters have the highest priority and always take precedence.
  2. If a config file is provided, the settings are taken from the config file unless they are overridden by command-line parameters. A command-line parameter must have been explicitly set to override the config file. Default values of command-line parameters do not override the config file.
  3. If neither command-line paramaters nor a config file are provided, the default settings as defined for the different CLI commands are applied.

Some config file options are still missing in this PR, for example, options to define database connections or general options such as the log level to use. These options will be added later.