### PR TITLE
Add export options for filtering LoDs

### DIFF
--- a/citydb-model/src/main/java/org/citydb/model/appearance/SurfaceDataProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/appearance/SurfaceDataProperty.java
@@ -72,6 +72,15 @@ public class SurfaceDataProperty extends Child implements InlineOrByReferencePro
         return Optional.ofNullable(reference);
     }
 
+    public boolean removeFromParent() {
+        Child parent = getParent().orElse(null);
+        if (parent instanceof Appearance appearance) {
+            return appearance.getSurfaceData().remove(this);
+        } else {
+            return false;
+        }
+    }
+
     @Override
     public SurfaceDataProperty setReference(Reference reference) {
         if (reference != null) {

--- a/citydb-model/src/main/java/org/citydb/model/geometry/Envelope.java
+++ b/citydb-model/src/main/java/org/citydb/model/geometry/Envelope.java
@@ -42,6 +42,12 @@ public class Envelope extends Child implements SpatialObject {
         return new Envelope(lowerCorner, upperCorner);
     }
 
+    public static Envelope empty() {
+        return new Envelope(
+                Coordinate.of(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE),
+                Coordinate.of(-Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE));
+    }
+
     public Coordinate getLowerCorner() {
         return lowerCorner;
     }
@@ -193,6 +199,15 @@ public class Envelope extends Child implements SpatialObject {
 
     public Envelope include(Geometry<?> geometry) {
         return include(geometry.getEnvelope());
+    }
+
+    public boolean isEmpty() {
+        return lowerCorner.getX() == Double.MAX_VALUE
+                && lowerCorner.getY() == Double.MAX_VALUE
+                && lowerCorner.getZ() == Double.MAX_VALUE
+                && upperCorner.getX() == -Double.MAX_VALUE
+                && upperCorner.getY() == -Double.MAX_VALUE
+                && upperCorner.getZ() == -Double.MAX_VALUE;
     }
 
     public Polygon convertToPolygon() {

--- a/citydb-model/src/main/java/org/citydb/model/property/AddressProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/AddressProperty.java
@@ -22,9 +22,11 @@
 package org.citydb.model.property;
 
 import org.citydb.model.address.Address;
+import org.citydb.model.common.Child;
 import org.citydb.model.common.InlineOrByReferenceProperty;
 import org.citydb.model.common.Name;
 import org.citydb.model.common.Reference;
+import org.citydb.model.feature.Feature;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -83,6 +85,18 @@ public class AddressProperty extends Property<AddressProperty> implements Inline
         }
 
         return this;
+    }
+
+    @Override
+    public boolean removeFromParent() {
+        Child parent = getParent().orElse(null);
+        if (parent instanceof Feature feature) {
+            return feature.getAddresses().remove(this);
+        } else if (parent instanceof Attribute attribute) {
+            return attribute.getProperties().remove(this);
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/citydb-model/src/main/java/org/citydb/model/property/AppearanceProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/AppearanceProperty.java
@@ -22,8 +22,11 @@
 package org.citydb.model.property;
 
 import org.citydb.model.appearance.Appearance;
+import org.citydb.model.common.Child;
 import org.citydb.model.common.InlineProperty;
 import org.citydb.model.common.Name;
+import org.citydb.model.feature.Feature;
+import org.citydb.model.geometry.ImplicitGeometry;
 
 import java.util.Objects;
 
@@ -52,6 +55,20 @@ public class AppearanceProperty extends Property<AppearanceProperty> implements 
         }
 
         return this;
+    }
+
+    @Override
+    public boolean removeFromParent() {
+        Child parent = getParent().orElse(null);
+        if (parent instanceof Feature feature) {
+            return feature.getAppearances().remove(this);
+        } else if (parent instanceof ImplicitGeometry geometry) {
+            return geometry.getAppearances().remove(this);
+        } else if (parent instanceof Attribute attribute) {
+            return attribute.getProperties().remove(this);
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/citydb-model/src/main/java/org/citydb/model/property/Attribute.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/Attribute.java
@@ -21,8 +21,10 @@
 
 package org.citydb.model.property;
 
+import org.citydb.model.common.Child;
 import org.citydb.model.common.Name;
 import org.citydb.model.common.PropertyMap;
+import org.citydb.model.feature.Feature;
 
 import java.time.OffsetDateTime;
 import java.util.Collection;
@@ -201,6 +203,18 @@ public class Attribute extends Property<Attribute> {
         }
 
         return this;
+    }
+
+    @Override
+    public boolean removeFromParent() {
+        Child parent = getParent().orElse(null);
+        if (parent instanceof Feature feature) {
+            return feature.getAttributes().remove(this);
+        } else if (parent instanceof Attribute attribute) {
+            return attribute.getProperties().remove(this);
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/citydb-model/src/main/java/org/citydb/model/property/FeatureProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/FeatureProperty.java
@@ -21,10 +21,7 @@
 
 package org.citydb.model.property;
 
-import org.citydb.model.common.InlineOrByReferenceProperty;
-import org.citydb.model.common.Name;
-import org.citydb.model.common.Reference;
-import org.citydb.model.common.RelationType;
+import org.citydb.model.common.*;
 import org.citydb.model.feature.Feature;
 
 import java.util.Objects;
@@ -110,6 +107,18 @@ public class FeatureProperty extends Property<FeatureProperty> implements Inline
     public FeatureProperty setRelationType(RelationType relationType) {
         this.relationType = relationType;
         return this;
+    }
+
+    @Override
+    public boolean removeFromParent() {
+        Child parent = getParent().orElse(null);
+        if (parent instanceof Feature feature) {
+            return feature.getFeatures().remove(this);
+        } else if (parent instanceof Attribute attribute) {
+            return attribute.getProperties().remove(this);
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/citydb-model/src/main/java/org/citydb/model/property/GeometryProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/GeometryProperty.java
@@ -21,8 +21,10 @@
 
 package org.citydb.model.property;
 
+import org.citydb.model.common.Child;
 import org.citydb.model.common.InlineProperty;
 import org.citydb.model.common.Name;
+import org.citydb.model.feature.Feature;
 import org.citydb.model.geometry.Geometry;
 
 import java.util.Objects;
@@ -68,6 +70,18 @@ public class GeometryProperty extends Property<GeometryProperty> implements Inli
     public GeometryProperty setLod(int lod) {
         this.lod = String.valueOf(lod);
         return this;
+    }
+
+    @Override
+    public boolean removeFromParent() {
+        Child parent = getParent().orElse(null);
+        if (parent instanceof Feature feature) {
+            return feature.getGeometries().remove(this);
+        } else if (parent instanceof Attribute attribute) {
+            return attribute.getProperties().remove(this);
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/citydb-model/src/main/java/org/citydb/model/property/ImplicitGeometryProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/ImplicitGeometryProperty.java
@@ -21,9 +21,11 @@
 
 package org.citydb.model.property;
 
+import org.citydb.model.common.Child;
 import org.citydb.model.common.InlineOrByReferenceProperty;
 import org.citydb.model.common.Name;
 import org.citydb.model.common.Reference;
+import org.citydb.model.feature.Feature;
 import org.citydb.model.geometry.ImplicitGeometry;
 import org.citydb.model.geometry.Point;
 
@@ -124,6 +126,18 @@ public class ImplicitGeometryProperty extends Property<ImplicitGeometryProperty>
     public ImplicitGeometryProperty setLod(int lod) {
         this.lod = String.valueOf(lod);
         return this;
+    }
+
+    @Override
+    public boolean removeFromParent() {
+        Child parent = getParent().orElse(null);
+        if (parent instanceof Feature feature) {
+            return feature.getImplicitGeometries().remove(this);
+        } else if (parent instanceof Attribute attribute) {
+            return attribute.getProperties().remove(this);
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/citydb-model/src/main/java/org/citydb/model/property/Property.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/Property.java
@@ -33,6 +33,8 @@ public abstract class Property<T extends Property<?>> extends Child implements D
     private Name dataType;
     private PropertyDescriptor descriptor;
 
+    public abstract boolean removeFromParent();
+
     abstract T self();
 
     Property(Name name, Name dataType) {

--- a/citydb-operation/src/main/java/module-info.java
+++ b/citydb-operation/src/main/java/module-info.java
@@ -14,6 +14,7 @@ module org.citydb.operation {
     exports org.citydb.operation.exporter.feature;
     exports org.citydb.operation.exporter.geometry;
     exports org.citydb.operation.exporter.hierarchy;
+    exports org.citydb.operation.exporter.options;
     exports org.citydb.operation.exporter.property;
     exports org.citydb.operation.exporter.util;
     exports org.citydb.operation.importer;

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/ExportOptions.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/ExportOptions.java
@@ -27,6 +27,7 @@ import org.citydb.config.common.SrsReference;
 import org.citydb.core.concurrent.LazyCheckedInitializer;
 import org.citydb.core.file.OutputFile;
 import org.citydb.core.file.output.RegularOutputFile;
+import org.citydb.operation.exporter.options.LodOptions;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -44,6 +45,7 @@ public class ExportOptions {
     private int numberOfThreads;
     private int numberOfTextureBuckets;
     private SrsReference targetSrs;
+    private LodOptions lodOptions;
 
     public OutputFile getOutputFile() {
         if (outputFile == null) {
@@ -91,6 +93,15 @@ public class ExportOptions {
 
     public ExportOptions setTargetSrs(SrsReference targetSrs) {
         this.targetSrs = targetSrs;
+        return this;
+    }
+
+    public Optional<LodOptions> getLodOptions() {
+        return Optional.ofNullable(lodOptions);
+    }
+
+    public ExportOptions setLodOptions(LodOptions lodOptions) {
+        this.lodOptions = lodOptions;
         return this;
     }
 }

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/options/LodMode.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/options/LodMode.java
@@ -1,0 +1,53 @@
+/*
+ * citydb-tool - Command-line tool for the 3D City Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2022-2024
+ * virtualcitysystems GmbH, Germany
+ * https://vc.systems/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.operation.exporter.options;
+
+public enum LodMode {
+    KEEP("keep"),
+    REMOVE("remove"),
+    MINIMUM("minimum"),
+    MAXIMUM("maximum");
+
+    private final String value;
+
+    LodMode(String value) {
+        this.value = value;
+    }
+
+    public String toValue() {
+        return value;
+    }
+
+    public static LodMode fromValue(String value) {
+        for (LodMode v : LodMode.values()) {
+            if (v.value.equals(value))
+                return v;
+        }
+
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/options/LodOptions.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/options/LodOptions.java
@@ -1,0 +1,68 @@
+/*
+ * citydb-tool - Command-line tool for the 3D City Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2022-2024
+ * virtualcitysystems GmbH, Germany
+ * https://vc.systems/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.operation.exporter.options;
+
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.annotation.JSONField;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class LodOptions {
+    private Set<String> lods;
+    @JSONField(serializeFeatures = JSONWriter.Feature.WriteEnumUsingToString)
+    private LodMode mode;
+
+    public Set<String> getLods() {
+        if (lods == null) {
+            lods = new HashSet<>();
+        }
+
+        return lods;
+    }
+
+    public LodOptions setLods(Set<String> lods) {
+        this.lods = lods;
+        return this;
+    }
+
+    public LodOptions withLod(String lod) {
+        if (lod != null) {
+            getLods().add(lod);
+        }
+
+        return this;
+    }
+
+    public LodOptions withLod(int lod) {
+        return withLod(String.valueOf(lod));
+    }
+
+    public LodMode getMode() {
+        return mode != null ? mode : LodMode.KEEP;
+    }
+
+    public LodOptions setMode(LodMode mode) {
+        this.mode = mode;
+        return this;
+    }
+}

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/util/AppearanceHelper.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/util/AppearanceHelper.java
@@ -1,0 +1,136 @@
+/*
+ * citydb-tool - Command-line tool for the 3D City Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2022-2024
+ * virtualcitysystems GmbH, Germany
+ * https://vc.systems/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.operation.exporter.util;
+
+import org.citydb.model.appearance.*;
+import org.citydb.model.common.DatabaseDescriptor;
+import org.citydb.model.common.Visitable;
+import org.citydb.model.feature.Feature;
+import org.citydb.model.geometry.LinearRing;
+import org.citydb.model.geometry.Polygon;
+import org.citydb.model.geometry.Surface;
+import org.citydb.model.property.AppearanceProperty;
+import org.citydb.model.walker.ModelWalker;
+import org.citydb.operation.exporter.ExportHelper;
+
+import java.util.*;
+
+public class AppearanceHelper {
+    private final ExportHelper helper;
+
+    AppearanceHelper(ExportHelper helper) {
+        this.helper = helper;
+    }
+
+    void assignSurfaceData(Visitable visitable, SurfaceDataMapper surfaceDataMapper) {
+        Map<String, Surface<?>> surfaces = new HashMap<>();
+        visitable.accept(new ModelWalker() {
+            @Override
+            public void visit(Surface<?> surface) {
+                long geometryDataId = surface.getRootGeometry().getDescriptor()
+                        .map(DatabaseDescriptor::getId)
+                        .orElse(0L);
+                surface.getObjectId().ifPresent(objectId -> surfaces.put(geometryDataId + "#" + objectId, surface));
+                super.visit(surface);
+            }
+        });
+
+        visitable.accept(new ModelWalker() {
+            @Override
+            public void visit(X3DMaterial material) {
+                surfaceDataMapper.getMaterialMappings(material).stream()
+                        .map(surfaces::get)
+                        .filter(Objects::nonNull)
+                        .forEach(material::addTarget);
+            }
+
+            @Override
+            public void visit(ParameterizedTexture texture) {
+                for (Map.Entry<String, List<Double>> entry : surfaceDataMapper
+                        .getWorldToTextureMappings(texture).entrySet()) {
+                    Surface<?> surface = surfaces.get(entry.getKey());
+                    if (surface != null) {
+                        texture.addWorldToTextureMapping(surface, entry.getValue());
+                    }
+                }
+
+                for (Map.Entry<String, List<List<TextureCoordinate>>> entry : surfaceDataMapper
+                        .getTextureMappings(texture).entrySet()) {
+                    Surface<?> surface = surfaces.get(entry.getKey());
+                    if (surface instanceof Polygon polygon) {
+                        List<LinearRing> rings = polygon.getRings();
+                        if (rings.size() == entry.getValue().size()) {
+                            for (int i = 0; i < rings.size(); i++) {
+                                List<TextureCoordinate> textureCoordinates = entry.getValue().get(i);
+                                if (textureCoordinates != null) {
+                                    LinearRing ring = rings.get(i).setObjectId(helper.createId());
+                                    texture.addTextureCoordinates(ring, textureCoordinates);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public void visit(GeoreferencedTexture texture) {
+                surfaceDataMapper.getGeoreferencedTextureMappings(texture).stream()
+                        .map(surfaces::get)
+                        .filter(Objects::nonNull)
+                        .forEach(texture::addTarget);
+            }
+        });
+    }
+
+    Set<String> removeEmptySurfaceData(Feature feature) {
+        Set<String> surfaceDataIds = new HashSet<>();
+        feature.accept(new ModelWalker() {
+            @Override
+            public void visit(Appearance appearance) {
+                Iterator<SurfaceDataProperty> iterator = appearance.getSurfaceData().iterator();
+                while (iterator.hasNext()) {
+                    SurfaceData<?> surfaceData = iterator.next().getObject().orElse(null);
+                    if ((surfaceData instanceof ParameterizedTexture texture
+                            && !texture.hasTextureCoordinates() && !texture.hasWorldToTextureMappings())
+                            || (surfaceData instanceof X3DMaterial material && !material.hasTargets())
+                            || (surfaceData instanceof GeoreferencedTexture geoTexture && !geoTexture.hasTargets())) {
+                        surfaceData.getObjectId().ifPresent(surfaceDataIds::add);
+                        iterator.remove();
+                    }
+                }
+            }
+        });
+
+        return surfaceDataIds;
+    }
+
+    void removeEmptyAppearances(Feature feature) {
+        feature.accept(new ModelWalker() {
+            @Override
+            public void visit(AppearanceProperty property) {
+                if (!property.getObject().hasSurfaceData()) {
+                    property.removeFromParent();
+                }
+            }
+        });
+    }
+}

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/util/EnvelopeHelper.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/util/EnvelopeHelper.java
@@ -1,0 +1,122 @@
+/*
+ * citydb-tool - Command-line tool for the 3D City Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2022-2024
+ * virtualcitysystems GmbH, Germany
+ * https://vc.systems/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.operation.exporter.util;
+
+import org.citydb.model.common.Reference;
+import org.citydb.model.common.RelationType;
+import org.citydb.model.feature.Feature;
+import org.citydb.model.geometry.Coordinate;
+import org.citydb.model.geometry.Envelope;
+import org.citydb.model.geometry.ImplicitGeometry;
+import org.citydb.model.geometry.Point;
+import org.citydb.model.property.FeatureProperty;
+import org.citydb.model.property.ImplicitGeometryProperty;
+import org.citydb.model.util.GeometryInfo;
+import org.citydb.model.walker.ModelWalker;
+import org.citydb.operation.exporter.ExportHelper;
+
+import java.util.*;
+
+public class EnvelopeHelper {
+    private final ExportHelper helper;
+
+    EnvelopeHelper(ExportHelper helper) {
+        this.helper = helper;
+    }
+
+    public void updateEnvelope(Feature feature) {
+        Map<String, ImplicitGeometry> implicitGeometries = new HashMap<>();
+        feature.accept(new ModelWalker() {
+            @Override
+            public void visit(ImplicitGeometry implicitGeometry) {
+                implicitGeometry.getObjectId().ifPresent(objectId ->
+                        implicitGeometries.put(objectId, implicitGeometry));
+            }
+        });
+
+        updateEnvelope(feature, implicitGeometries);
+    }
+
+    private void updateEnvelope(Feature feature, Map<String, ImplicitGeometry> implicitGeometries) {
+        Deque<Envelope> envelopes = new ArrayDeque<>();
+        feature.accept(new ModelWalker() {
+            @Override
+            public void visit(Feature feature) {
+                envelopes.push(computeEnvelope(feature, implicitGeometries));
+                super.visit(feature);
+
+                Envelope envelope = envelopes.pop();
+                if (!envelope.isEmpty()) {
+                    feature.setEnvelope(envelope);
+                    if (!envelopes.isEmpty()) {
+                        envelopes.peek().include(envelope);
+                    }
+                }
+            }
+
+            @Override
+            public void visit(FeatureProperty property) {
+                if (property.getRelationType() == RelationType.CONTAINS) {
+                    super.visit(property);
+                }
+            }
+        });
+    }
+
+    private Envelope computeEnvelope(Feature feature, Map<String, ImplicitGeometry> implicitGeometries) {
+        Envelope envelope = Envelope.empty();
+        GeometryInfo geometryInfo = feature.getGeometryInfo(GeometryInfo.Mode.SKIP_NESTED_FEATURES);
+
+        if (helper.getAdapter().getDatabaseMetadata().getSpatialReference().getSRID() == helper.getSRID()
+                || !geometryInfo.hasImplicitGeometries()) {
+            if (geometryInfo.hasGeometries()) {
+                geometryInfo.getGeometries().stream()
+                        .map(property -> property.getObject().getEnvelope())
+                        .forEach(envelope::include);
+            }
+
+            if (geometryInfo.hasImplicitGeometries()) {
+                for (ImplicitGeometryProperty property : geometryInfo.getImplicitGeometries()) {
+                    List<Double> transformationMatrix = property.getTransformationMatrix().orElse(null);
+                    Point referencePoint = property.getReferencePoint().orElse(null);
+                    if (transformationMatrix != null
+                            && transformationMatrix.size() > 11
+                            && referencePoint != null) {
+                        ImplicitGeometry geometry = property.getObject().orElse(
+                                implicitGeometries.get(property.getReference()
+                                        .map(Reference::getTarget).orElse(null)));
+                        if (geometry != null) {
+                            envelope.include(geometry.getEnvelope(transformationMatrix, referencePoint));
+                        } else {
+                            envelope.include(Point.of(Coordinate.of(
+                                    referencePoint.getCoordinate().getX() + transformationMatrix.get(3),
+                                    referencePoint.getCoordinate().getY() + transformationMatrix.get(7),
+                                    referencePoint.getCoordinate().getZ() + transformationMatrix.get(11))));
+                        }
+                    }
+                }
+            }
+        }
+
+        return envelope;
+    }
+}

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/util/LodFilter.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/util/LodFilter.java
@@ -1,0 +1,140 @@
+/*
+ * citydb-tool - Command-line tool for the 3D City Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2022-2024
+ * virtualcitysystems GmbH, Germany
+ * https://vc.systems/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.operation.exporter.util;
+
+import org.citydb.model.feature.Feature;
+import org.citydb.model.geometry.ImplicitGeometry;
+import org.citydb.model.property.FeatureProperty;
+import org.citydb.model.property.Property;
+import org.citydb.model.util.GeometryInfo;
+import org.citydb.model.walker.ModelWalker;
+import org.citydb.operation.exporter.options.LodMode;
+import org.citydb.operation.exporter.options.LodOptions;
+
+import java.util.*;
+
+public class LodFilter {
+    private final Set<String> lods;
+    private final LodMode mode;
+    private final boolean isEnabled;
+    private boolean hasRemovedGeometry;
+
+    public LodFilter(LodOptions options) {
+        Objects.requireNonNull(options, "The LoD filter options must not be null.");
+        lods = options.getLods();
+        mode = options.getMode();
+        isEnabled = switch (mode) {
+            case KEEP, REMOVE -> !lods.isEmpty();
+            case MINIMUM, MAXIMUM -> true;
+        };
+    }
+
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+
+    boolean hasRemovedGeometry() {
+        return hasRemovedGeometry;
+    }
+
+    public boolean filter(String lod) {
+        if (isEnabled && lod != null) {
+            if (switch (mode) {
+                case KEEP -> lods.contains(lod);
+                case REMOVE -> !lods.contains(lod);
+                case MINIMUM, MAXIMUM -> lods.isEmpty() || lods.contains(lod);
+            }) {
+                return true;
+            } else {
+                hasRemovedGeometry = true;
+                return false;
+            }
+        } else {
+            return true;
+        }
+    }
+
+    Map<String, ImplicitGeometry> removeGeometries(Feature feature) {
+        if (isEnabled && (mode == LodMode.MINIMUM || mode == LodMode.MAXIMUM)) {
+            Map<String, ImplicitGeometry> implicitGeometries = new HashMap<>();
+            GeometryInfo geometryInfo = feature.getGeometryInfo(GeometryInfo.Mode.INCLUDE_CONTAINED_FEATURES);
+            String targetLod = geometryInfo.getLods().stream()
+                    .min(mode == LodMode.MINIMUM ? Comparator.naturalOrder() : Comparator.reverseOrder())
+                    .filter(lod -> lods.isEmpty() || lods.contains(lod))
+                    .orElse("");
+
+            if (geometryInfo.hasGeometries()) {
+                geometryInfo.getGeometries().stream()
+                        .filter(property -> !targetLod.equals(property.getLod().orElse(targetLod)))
+                        .forEach(this::removeGeometryProperty);
+            }
+
+            if (geometryInfo.hasImplicitGeometries()) {
+                geometryInfo.getImplicitGeometries().stream()
+                        .filter(property -> !targetLod.equals(property.getLod().orElse(targetLod)))
+                        .forEach(property -> {
+                            removeGeometryProperty(property);
+                            property.getObject().ifPresent(implicitGeometry ->
+                                    implicitGeometry.getObjectId().ifPresent(objectId ->
+                                            implicitGeometries.put(objectId, implicitGeometry)));
+                        });
+            }
+
+            return implicitGeometries;
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    Set<String> removeEmptyFeatures(Feature feature) {
+        if (hasRemovedGeometry) {
+            Set<String> featureIds = new HashSet<>();
+            feature.accept(new ModelWalker() {
+                @Override
+                public void visit(FeatureProperty property) {
+                    Feature child = property.getObject().orElse(null);
+                    if (child != null && hasEmptyGeometry(child)) {
+                        property.removeFromParent();
+                        child.getObjectId().ifPresent(featureIds::add);
+                    } else {
+                        super.visit(property);
+                    }
+                }
+            });
+
+            return featureIds;
+        } else {
+            return Collections.emptySet();
+        }
+    }
+
+    private boolean hasEmptyGeometry(Feature feature) {
+        GeometryInfo geometryInfo = feature.getGeometryInfo(GeometryInfo.Mode.INCLUDE_CONTAINED_FEATURES);
+        return !geometryInfo.hasGeometries()
+                && !geometryInfo.hasImplicitGeometries();
+    }
+
+    private void removeGeometryProperty(Property<?> property) {
+        hasRemovedGeometry = true;
+        property.removeFromParent();
+    }
+}

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/util/SurfaceDataMapper.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/util/SurfaceDataMapper.java
@@ -133,7 +133,7 @@ public class SurfaceDataMapper {
         return geometryDataId + "#" + objectId;
     }
 
-    void clear() {
+    public void clear() {
         materialMappings.clear();
         textureMappings.clear();
         worldToTextureMappings.clear();


### PR DESCRIPTION
This PR adds options for filtering LoDs during exports. It only addresses the Java API of the export module. The extension of the Query API and the CLI with LoD filter functions will be dealt with in subsequent PRs, which will build on this PR. 