### PR TITLE
Add API to compute extent

### DIFF
--- a/citydb-database-postgres/src/main/java/org/citydb/database/postgres/BoxParser.java
+++ b/citydb-database-postgres/src/main/java/org/citydb/database/postgres/BoxParser.java
@@ -1,0 +1,97 @@
+/*
+ * citydb-tool - Command-line tool for the 3D City Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2022-2024
+ * virtualcitysystems GmbH, Germany
+ * https://vc.systems/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.database.postgres;
+
+import org.citydb.database.geometry.GeometryException;
+import org.citydb.model.geometry.Coordinate;
+import org.citydb.model.geometry.Envelope;
+
+public class BoxParser {
+
+    public Envelope parse(String text) throws GeometryException {
+        return text != null ? readBox(text) : null;
+    }
+
+    private Envelope readBox(String text) throws GeometryException {
+        String[] parts = split(text);
+        Integer srid = parts[0] != null ? getSRID(parts[0]) : null;
+
+        Envelope envelope = switch (parts[1]) {
+            case "BOX" -> readBox(parts[2], 2);
+            case "BOX3D" -> readBox(parts[2], 3);
+            default -> throw new GeometryException("Unsupported box geometry type '" + parts[1] + "'.");
+        };
+
+        return envelope.setSRID(srid);
+    }
+
+    private Envelope readBox(String text, int dimension) throws GeometryException {
+        String[] parts = text.split(",");
+        if (parts.length == 2) {
+            Coordinate lowerCorner = getCoordinate(parts[0], dimension);
+            Coordinate upperCorner = getCoordinate(parts[1], dimension);
+            return Envelope.of(lowerCorner, upperCorner);
+        } else {
+            throw new GeometryException("Failed to parse lower and upper corner of box geometry.");
+        }
+    }
+
+    private Coordinate getCoordinate(String text, int dimension) throws GeometryException {
+        String[] parts = text.trim().split(" ");
+        if (parts.length == dimension) {
+            double x = getNumber(parts[0]);
+            double y = getNumber(parts[1]);
+            return parts.length == 2 ?
+                    Coordinate.of(x, y) :
+                    Coordinate.of(x, y, getNumber(parts[2]));
+        } else {
+            throw new GeometryException("Invalid dimension of box coordinate.");
+        }
+    }
+
+    private Double getNumber(String text) throws GeometryException {
+        try {
+            return Double.parseDouble(text);
+        } catch (NumberFormatException e) {
+            throw new GeometryException("Invalid number: " + text);
+        }
+    }
+
+    private Integer getSRID(String text) throws GeometryException {
+        try {
+            return Integer.parseInt(text);
+        } catch (NumberFormatException e) {
+            throw new GeometryException("Invalid SRID: " + text);
+        }
+    }
+
+    private String[] split(String text) {
+        int srid = text.indexOf("SRID=");
+        int semicolon = text.indexOf(";", srid);
+        int lParen = text.indexOf("(", semicolon);
+        int rParen = text.indexOf(")", lParen);
+
+        return new String[]{srid != -1 ? text.substring(srid + 5, semicolon).trim() : null,
+                text.substring(semicolon != -1 ? semicolon + 1 : 0, lParen != -1 ? lParen : 0).trim(),
+                text.substring(lParen != -1 ? lParen + 1 : 0, rParen != -1 ? rParen : text.length())};
+    }
+}

--- a/citydb-database-postgres/src/main/java/org/citydb/database/postgres/GeometryAdapter.java
+++ b/citydb-database-postgres/src/main/java/org/citydb/database/postgres/GeometryAdapter.java
@@ -26,12 +26,15 @@ import org.citydb.database.geometry.GeometryException;
 import org.citydb.database.geometry.WKBParser;
 import org.citydb.database.geometry.WKBWriter;
 import org.citydb.database.geometry.WKTWriter;
+import org.citydb.model.geometry.Envelope;
 import org.citydb.model.geometry.Geometry;
+import org.postgresql.util.PGobject;
 
 import java.sql.*;
 
 public class GeometryAdapter extends org.citydb.database.adapter.GeometryAdapter {
     private final WKBParser parser = new WKBParser();
+    private final BoxParser boxParser = new BoxParser();
     private final WKBWriter writer = new WKBWriter().includeSRID(true);
     private final WKTWriter textWriter = new WKTWriter().includeSRID(true);
     private final SpatialOperationHelper spatialOperationHelper = new SpatialOperationHelper();
@@ -53,6 +56,16 @@ public class GeometryAdapter extends org.citydb.database.adapter.GeometryAdapter
     @Override
     public Geometry<?> getGeometry(Object geometryObject) throws GeometryException {
         return parser.parse(geometryObject);
+    }
+
+    @Override
+    public Envelope getEnvelope(Object geometryObject) throws GeometryException {
+        if (geometryObject instanceof PGobject object && object.getType().equals("geometry")) {
+            Geometry<?> geometry = getGeometry(geometryObject);
+            return geometry != null ? geometry.getEnvelope() : null;
+        } else {
+            return boxParser.parse(geometryObject.toString());
+        }
     }
 
     @Override

--- a/citydb-database-postgres/src/main/java/org/citydb/database/postgres/SpatialOperationHelper.java
+++ b/citydb-database-postgres/src/main/java/org/citydb/database/postgres/SpatialOperationHelper.java
@@ -33,7 +33,12 @@ public class SpatialOperationHelper implements org.citydb.database.util.SpatialO
     private final StringLiteral TRUE = StringLiteral.of("TRUE");
 
     @Override
-    public ScalarExpression transform(ScalarExpression operand, int srid) {
+    public Function extent(ScalarExpression operand) {
+        return Function.of("st_3dextent", operand);
+    }
+
+    @Override
+    public Function transform(ScalarExpression operand, int srid) {
         return Function.of("st_transform", operand, IntegerLiteral.of(srid));
     }
 

--- a/citydb-database/src/main/java/org/citydb/database/adapter/GeometryAdapter.java
+++ b/citydb-database/src/main/java/org/citydb/database/adapter/GeometryAdapter.java
@@ -30,6 +30,7 @@ import org.citydb.database.metadata.SpatialReference;
 import org.citydb.database.util.SpatialOperationHelper;
 import org.citydb.database.util.SrsHelper;
 import org.citydb.database.util.SrsParseException;
+import org.citydb.model.geometry.Envelope;
 import org.citydb.model.geometry.Geometry;
 
 import java.sql.Connection;
@@ -52,6 +53,8 @@ public abstract class GeometryAdapter {
     public abstract String getGeometryTypeName();
 
     public abstract Geometry<?> getGeometry(Object geometryObject) throws GeometryException;
+
+    public abstract Envelope getEnvelope(Object geometryObject) throws GeometryException;
 
     public abstract Object getGeometry(Geometry<?> geometry, boolean force3D) throws GeometryException;
 

--- a/citydb-database/src/main/java/org/citydb/database/geometry/WKTParser.java
+++ b/citydb-database/src/main/java/org/citydb/database/geometry/WKTParser.java
@@ -110,15 +110,11 @@ public class WKTParser {
 
         boolean nested = lookAheadWord(tokenizer).equals(L_PAREN);
         List<Point> points = new ArrayList<>();
-        points.add(nested ?
-                readPoint(tokenizer, is3D) :
-                Point.of(getCoordinate(tokenizer, is3D)));
-
-        while (nextCloserOrComma(tokenizer).equals(COMMA)) {
+        do {
             points.add(nested ?
                     readPoint(tokenizer, is3D) :
                     Point.of(getCoordinate(tokenizer, is3D)));
-        }
+        } while (nextCloserOrComma(tokenizer).equals(COMMA));
 
         return MultiPoint.of(points);
     }
@@ -223,7 +219,7 @@ public class WKTParser {
             } else {
                 try {
                     return Double.parseDouble(tokenizer.sval);
-                } catch (NumberFormatException ex) {
+                } catch (NumberFormatException e) {
                     throw new GeometryException("Invalid number: " + tokenizer.sval);
                 }
             }

--- a/citydb-database/src/main/java/org/citydb/database/util/SpatialOperationHelper.java
+++ b/citydb-database/src/main/java/org/citydb/database/util/SpatialOperationHelper.java
@@ -21,11 +21,14 @@
 
 package org.citydb.database.util;
 
+import org.citydb.sqlbuilder.function.Function;
 import org.citydb.sqlbuilder.literal.ScalarExpression;
 import org.citydb.sqlbuilder.operation.BooleanExpression;
 
 public interface SpatialOperationHelper {
-    ScalarExpression transform(ScalarExpression operand, int srid);
+    Function extent(ScalarExpression operand);
+
+    Function transform(ScalarExpression operand, int srid);
 
     BooleanExpression bbox(ScalarExpression leftOperand, ScalarExpression rightOperand);
 


### PR DESCRIPTION
This PR adds a `computeExtent` method to the `QueryExecutor` that lets you compute the minimum 3D bounding box containing all features requested by a query.