### PR TITLE
Docker base image updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ WORKDIR /build
 COPY . /build
 
 # Build
-RUN chmod u+x ./gradlew && ./gradlew installDist
+RUN set -x && \
+    chmod u+x ./gradlew && ./gradlew installDist
 
 # Runtime stage ###############################################################
 # Base image
@@ -30,12 +31,11 @@ ENV CITYDB_TOOL_VERSION=${CITYDB_TOOL_VERSION}
 COPY --from=builder /build/citydb-cli/build/install/citydb-tool /opt/citydb-tool
 
 # Run as non-root user, put start script in path and set permissions
-RUN groupadd --gid 1000 -r citydb-tool && \
-    useradd --uid 1000 --gid 1000 -d /data -m -r --no-log-init citydb-tool && \
+RUN set -x && \
     ln -sf /opt/citydb-tool/citydb /usr/local/bin
 
-WORKDIR /data
 USER 1000
+WORKDIR /data
 
 ENTRYPOINT ["citydb"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 
 # Fetch & build stage #########################################################
 # ARGS
-ARG BUILDER_IMAGE_TAG='21-jdk-jammy'
-ARG RUNTIME_IMAGE_TAG='21-jre-jammy'
+ARG BUILDER_IMAGE_TAG='21-jdk-noble'
+ARG RUNTIME_IMAGE_TAG='21-jre-noble'
 
 # Base image
 FROM eclipse-temurin:${BUILDER_IMAGE_TAG} AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 
 # Fetch & build stage #########################################################
 # ARGS
-ARG BUILDER_IMAGE_TAG='17-jdk-jammy'
-ARG RUNTIME_IMAGE_TAG='17-jdk-jammy'
+ARG BUILDER_IMAGE_TAG='21-jdk-jammy'
+ARG RUNTIME_IMAGE_TAG='21-jdk-jammy'
 
 # Base image
 FROM eclipse-temurin:${BUILDER_IMAGE_TAG} AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # Fetch & build stage #########################################################
 # ARGS
 ARG BUILDER_IMAGE_TAG='21-jdk-jammy'
-ARG RUNTIME_IMAGE_TAG='21-jdk-jammy'
+ARG RUNTIME_IMAGE_TAG='21-jre-jammy'
 
 # Base image
 FROM eclipse-temurin:${BUILDER_IMAGE_TAG} AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV CITYDB_TOOL_VERSION=${CITYDB_TOOL_VERSION}
 # Copy from builder
 COPY --from=builder /build/citydb-cli/build/install/citydb-tool /opt/citydb-tool
 
-# Run as non-root user, put start script in path and set permissions
+# Put start script in path
 RUN set -x && \
     ln -sf /opt/citydb-tool/citydb /usr/local/bin
 


### PR DESCRIPTION
Update Docker base images to latest Java LTS v21 and latest Ubuntu.

@clausnagel
Do you recall if there was a specific reason why we choose `jdk` for the runtime image? Is the JDK a requirement for the tool at runtime? If no, we could save ~2/3 of the image size.

I tested to run the tool (no import or export operation), there were no errors.
