### PR TITLE
Docker images for PRs

### DIFF
--- a/.github/workflows/cleanup-dev-images.yml
+++ b/.github/workflows/cleanup-dev-images.yml
@@ -1,0 +1,36 @@
+name: Cleanup PR images
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: "Pull Request Number"
+        required: true
+        default: "0"
+
+env:
+  PACKAGE_NAME: citydb-tool-dev
+
+jobs:
+  ghcr-cleanup-image:
+    if: github.event_name == 'pull_request'
+    name: ghcr cleanup action
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete image
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          delete-tags: "*pr-${{github.event.pull_request.number}}*"
+          package: ${{ env.PACKAGE_NAME }}
+
+  ghcr-cleanup-image-manual:
+    if: github.event_name == 'workflow_dispatch'
+    name: ghcr cleanup action
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete image
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          delete-tags: "*pr-${{ inputs.pr-number }}*"
+          package: ${{ env.PACKAGE_NAME }}

--- a/.github/workflows/docker-build-push-dev.yml
+++ b/.github/workflows/docker-build-push-dev.yml
@@ -88,54 +88,7 @@ jobs:
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-      - name: Extract metadata (tags, labels) for docker image
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}
-          tags: |
-            # Latest tag for PR, PR number only
-            type=ref,event=pr,prefix=3dcitydb-pr-,suffix=${{ matrix.variant }}
-            # Tag for with commit sha appended
-            type=ref,event=pr,prefix=3dcitydb-pr-,suffix=-{{sha}}${{ matrix.variant }}
-          labels: |
-            maintainer=Bruno Willenborg
-            maintainer.email=b.willenborg(at)tum.de
-            maintainer.organization=Chair of Geoinformatics, Technical University of Munich (TUM)
-            org.opencontainers.image.authors=Bruno Willenborg
-            org.opencontainers.image.vendor=3DCityDB Steering Committee
-            org.opencontainers.image.title=3D City Database PostgreSQL/PostGIS Docker image
-            org.opencontainers.image.description=Development Docker image for the 3D City Database based on PostgreSQL and PostGIS
-            org.opencontainers.image.url=https://github.com/3dcitydb/
-            org.opencontainers.image.documentation=https://3dcitydb.github.io/3dcitydb-mkdocs/3dcitydb/docker/
-            org.opencontainers.image.source=https://github.com/3dcitydb/3dcitydb
-      - name: Build and push image
-        id: docker_build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            BASEIMAGE_TAG=${{ matrix.baseimage-tag }}${{ matrix.variant }}
-            CITYDB_VERSION=${{ steps.short-sha.outputs.sha }}
-
       - name: Print image names
         run: |
-          echo "${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}${{ matrix.variant }}"
-          echo "${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}-${{ steps.short-sha.outputs.sha }}${{ matrix.variant }}"
+          echo "${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}"
+          echo "${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}-${{ steps.short-sha.outputs.sha }}"

--- a/.github/workflows/docker-build-push-dev.yml
+++ b/.github/workflows/docker-build-push-dev.yml
@@ -60,7 +60,7 @@ jobs:
             # Latest tag for PR, PR number only
             type=ref,event=pr,prefix=citydb-tool-pr-
             # Tag for with commit sha appended
-            type=ref,event=pr,prefix=citydb-tool-,suffix=-{{sha}}
+            type=ref,event=pr,prefix=citydb-tool-pr-,suffix=-{{sha}}
           labels: |
             maintainer=Bruno Willenborg
             maintainer.email=b.willenborg(at)tum.de

--- a/.github/workflows/docker-build-push-dev.yml
+++ b/.github/workflows/docker-build-push-dev.yml
@@ -1,0 +1,141 @@
+name: Build/push dev Docker images
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: "Pull Request Number"
+        required: true
+        default: "0"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: citydb-tool-dev
+  PLATFORMS: linux/amd64,linux/arm64
+
+jobs:
+  build-and-push-images:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Parse short sha
+        uses: benjlevesque/short-sha@v3.0
+        id: short-sha
+      - name: set lower case owner name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: "${{ github.repository_owner }}"
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Github Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ env.PLATFORMS }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: ${{ env.PLATFORMS }}
+      - name: Extract metadata (tags, labels) for docker image
+        id: meta
+        uses: docker/metadata-action@v5
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            # Latest tag for PR, PR number only
+            type=ref,event=pr,prefix=citydb-tool-pr-
+            # Tag for with commit sha appended
+            type=ref,event=pr,prefix=citydb-tool-,suffix=-{{sha}}
+          labels: |
+            maintainer=Bruno Willenborg
+            maintainer.email=b.willenborg(at)tum.de
+            maintainer.organization=Chair of Geoinformatics, Technical University of Munich (TUM)
+            org.opencontainers.image.authors=Bruno Willenborg
+            org.opencontainers.image.vendor=3DCityDB Steering Committee
+            org.opencontainers.image.title=3D City Database 5.0 CLI tool Docker image
+            org.opencontainers.image.description=3D City Database 5.0 CLI to import/export city model data and to run database operations
+            org.opencontainers.image.url=https://github.com/3dcitydb/
+            org.opencontainers.image.documentation=https://3dcitydb.github.io/3dcitydb-mkdocs/citydb-tool/docker/
+            org.opencontainers.image.source=https://github.com/3dcitydb/citydb-tool
+      - name: Build and publish
+        uses: docker/build-push-action@v6
+        id: docker_build
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ env.PLATFORMS }}
+          build-args: |
+            CITYDB_TOOL_VERSION=${{ steps.short-sha.outputs.sha }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          provenance: false
+          sbom: false
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+      - name: Extract metadata (tags, labels) for docker image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # Latest tag for PR, PR number only
+            type=ref,event=pr,prefix=3dcitydb-pr-,suffix=${{ matrix.variant }}
+            # Tag for with commit sha appended
+            type=ref,event=pr,prefix=3dcitydb-pr-,suffix=-{{sha}}${{ matrix.variant }}
+          labels: |
+            maintainer=Bruno Willenborg
+            maintainer.email=b.willenborg(at)tum.de
+            maintainer.organization=Chair of Geoinformatics, Technical University of Munich (TUM)
+            org.opencontainers.image.authors=Bruno Willenborg
+            org.opencontainers.image.vendor=3DCityDB Steering Committee
+            org.opencontainers.image.title=3D City Database PostgreSQL/PostGIS Docker image
+            org.opencontainers.image.description=Development Docker image for the 3D City Database based on PostgreSQL and PostGIS
+            org.opencontainers.image.url=https://github.com/3dcitydb/
+            org.opencontainers.image.documentation=https://3dcitydb.github.io/3dcitydb-mkdocs/3dcitydb/docker/
+            org.opencontainers.image.source=https://github.com/3dcitydb/3dcitydb
+      - name: Build and push image
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASEIMAGE_TAG=${{ matrix.baseimage-tag }}${{ matrix.variant }}
+            CITYDB_VERSION=${{ steps.short-sha.outputs.sha }}
+
+      - name: Print image names
+        run: |
+          echo "${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}${{ matrix.variant }}"
+          echo "${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}-${{ steps.short-sha.outputs.sha }}${{ matrix.variant }}"


### PR DESCRIPTION
Hey all,

this adds a workflow to build docker images for PRs and delete them, when the PR is closed (merged or closed without merge).

The new registry for development (PR) images is here:
https://github.com/3dcitydb/citydb-tool/pkgs/container/citydb-tool-dev
`ghcr.io/3dcitydb/citydb-tool-dev`

For each commit to a PR two image are released:

- `citydb-tool-pr-<PR_Nr.>-<COMMIT SHA>`: 
  This tag contains the commit hash and is helpful, when you need an image for specific commit.
   - `docker pull ghcr.io/3dcitydb/citydb-tool-dev:citydb-tool-55-4089cd6`

- `citydb-tool-pr-<PR_Nr.>`:
  This tag is _volatile_ and always points to the latest commit of the corresponding PR.
   - `docker pull ghcr.io/3dcitydb/citydb-tool-dev:citydb-tool-55`
 
> [!TIP]
> The workflow can be triggered manually too. You can give a PR number as input.

Here is an example of this PR from the registry.
![grafik](https://github.com/user-attachments/assets/7cfe2e41-8c71-4847-b0d3-eba737fa48ac)
