### PR TITLE
fix image name with commit sha

### DIFF
--- a/.github/workflows/docker-build-push-dev.yml
+++ b/.github/workflows/docker-build-push-dev.yml
@@ -21,16 +21,18 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Parse short sha
-        uses: benjlevesque/short-sha@v3.0
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Short SHA of latest commit to PR
+        run: |
+          tmp=${{ github.event.pull_request.head.sha }}
+          echo "sha_short=${tmp::7}" >> $GITHUB_OUTPUT
         id: short-sha
       - name: set lower case owner name
         run: |
           echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
         env:
           OWNER: "${{ github.repository_owner }}"
-      - name: Checkout repository
-        uses: actions/checkout@v4
       - name: Log in to the Github Container Registry
         uses: docker/login-action@v3
         with:
@@ -60,7 +62,7 @@ jobs:
             # Latest tag for PR, PR number only
             type=ref,event=pr,prefix=citydb-tool-pr-
             # Tag for with commit sha appended
-            type=ref,event=pr,prefix=citydb-tool-pr-,suffix=-{{sha}}
+            type=ref,event=pr,prefix=citydb-tool-pr-,suffix=-${{ steps.short-sha.outputs.sha_short }}
           labels: |
             maintainer=Bruno Willenborg
             maintainer.email=b.willenborg(at)tum.de
@@ -81,7 +83,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ env.PLATFORMS }}
           build-args: |
-            CITYDB_TOOL_VERSION=${{ steps.short-sha.outputs.sha }}
+            CITYDB_TOOL_VERSION=${{ steps.short-sha.outputs.sha_short }}
           annotations: ${{ steps.meta.outputs.annotations }}
           provenance: false
           sbom: false
@@ -91,4 +93,4 @@ jobs:
       - name: Print image names
         run: |
           echo "${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}"
-          echo "${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}-${{ steps.short-sha.outputs.sha }}"
+          echo "${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}-${{ steps.short-sha.outputs.sha_short }}"


### PR DESCRIPTION
@clausnagel
This explains the strange SHA we had before. Very misleading. Apparently, Github is performing a merge in the back to test for merge conflicts. The SHA we got is from that merge, that is done invisibly to the user. It should be working now.

https://github.com/orgs/community/discussions/25191#discussioncomment-3246770