### PR TITLE
Add command to test database connections

### DIFF
--- a/citydb-cli/src/main/java/module-info.java
+++ b/citydb-cli/src/main/java/module-info.java
@@ -34,6 +34,7 @@ module org.citydb.cli {
 
     opens org.citydb.cli to info.picocli;
     opens org.citydb.cli.common to info.picocli;
+    opens org.citydb.cli.connect to info.picocli;
     opens org.citydb.cli.deleter to info.picocli;
     opens org.citydb.cli.deleter.options to info.picocli;
     opens org.citydb.cli.exporter to info.picocli;

--- a/citydb-cli/src/main/java/org/citydb/cli/Launcher.java
+++ b/citydb-cli/src/main/java/org/citydb/cli/Launcher.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.citydb.cli.common.Command;
 import org.citydb.cli.common.ConfigOption;
 import org.citydb.cli.common.Option;
+import org.citydb.cli.connect.ConnectCommand;
 import org.citydb.cli.deleter.DeleteCommand;
 import org.citydb.cli.exporter.ExportCommand;
 import org.citydb.cli.extension.MainCommand;
@@ -125,6 +126,7 @@ public class Launcher implements Command, CommandLine.IVersionProvider {
         CommandLine cmd = new CommandLine(this);
 
         pluginManager.load(parsePluginsDirectory(args));
+        Command.addSubcommand(new ConnectCommand(), cmd, pluginManager);
         Command.addSubcommand(new InfoCommand(), cmd, pluginManager);
         Command.addSubcommand(new ImportCommand(), cmd, pluginManager);
         Command.addSubcommand(new ExportCommand(), cmd, pluginManager);

--- a/citydb-cli/src/main/java/org/citydb/cli/common/JsonOutputOptions.java
+++ b/citydb-cli/src/main/java/org/citydb/cli/common/JsonOutputOptions.java
@@ -50,13 +50,13 @@ public class JsonOutputOptions implements Option {
     }
 
     public OutputStream openStream() throws IOException {
-        if (!isOutputSpecified()) {
+        if (isOutputSpecified()) {
+            return writeToStdout ?
+                    Streams.nonClosing(System.out) :
+                    Files.newOutputStream(file);
+        } else {
             throw new IOException("No output option specified.");
         }
-
-        return writeToStdout ?
-                Streams.nonClosing(System.out) :
-                Files.newOutputStream(file);
     }
 
     @Override

--- a/citydb-cli/src/main/java/org/citydb/cli/connect/ConnectCommand.java
+++ b/citydb-cli/src/main/java/org/citydb/cli/connect/ConnectCommand.java
@@ -70,7 +70,7 @@ public class ConnectCommand implements Command {
     private int doConnect(DatabaseManager databaseManager) throws ExecutionException {
         ConnectionDetails connectionDetails = Objects.requireNonNullElseGet(connectionOptions, ConnectionOptions::new)
                 .toConnectionDetails()
-                .fillAbsentValuesFrom(getDefaultConnectionDetails())
+                .fillAbsentValuesFrom(getConnectionDetailsFromConfig())
                 .fillAbsentValuesFromEnv();
 
         logger.info("Testing connection to database {}.", connectionDetails.toConnectString());
@@ -125,7 +125,7 @@ public class ConnectCommand implements Command {
         }
     }
 
-    private ConnectionDetails getDefaultConnectionDetails() throws ExecutionException {
+    private ConnectionDetails getConnectionDetailsFromConfig() throws ExecutionException {
         try {
             DatabaseOptions options = config.get(DatabaseOptions.class);
             return options != null ? options.getDefaultConnection().orElse(null) : null;

--- a/citydb-cli/src/main/java/org/citydb/cli/connect/ConnectCommand.java
+++ b/citydb-cli/src/main/java/org/citydb/cli/connect/ConnectCommand.java
@@ -69,7 +69,8 @@ public class ConnectCommand implements Command {
 
     private int doConnect(DatabaseManager databaseManager) throws ExecutionException {
         ConnectionDetails connectionDetails = Objects.requireNonNullElseGet(connectionOptions, ConnectionOptions::new)
-                .toConnectionDetails(getDatabaseOptions())
+                .toConnectionDetails()
+                .fillAbsentValuesFrom(getDefaultConnectionDetails())
                 .fillAbsentValuesFromEnv();
 
         logger.info("Testing connection to database {}.", connectionDetails.toConnectString());
@@ -124,9 +125,10 @@ public class ConnectCommand implements Command {
         }
     }
 
-    private DatabaseOptions getDatabaseOptions() throws ExecutionException {
+    private ConnectionDetails getDefaultConnectionDetails() throws ExecutionException {
         try {
-            return config.get(DatabaseOptions.class);
+            DatabaseOptions options = config.get(DatabaseOptions.class);
+            return options != null ? options.getDefaultConnection().orElse(null) : null;
         } catch (ConfigException e) {
             throw new ExecutionException("Failed to get database options from config.", e);
         }

--- a/citydb-cli/src/main/java/org/citydb/cli/connect/ConnectCommand.java
+++ b/citydb-cli/src/main/java/org/citydb/cli/connect/ConnectCommand.java
@@ -1,0 +1,134 @@
+/*
+ * citydb-tool - Command-line tool for the 3D City Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2022-2025
+ * virtualcitysystems GmbH, Germany
+ * https://vc.systems/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.cli.connect;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONWriter;
+import org.apache.logging.log4j.Logger;
+import org.citydb.cli.ExecutionException;
+import org.citydb.cli.common.Command;
+import org.citydb.cli.common.ConfigOption;
+import org.citydb.cli.common.ConnectionOptions;
+import org.citydb.cli.common.JsonOutputOptions;
+import org.citydb.cli.logging.LoggerManager;
+import org.citydb.config.Config;
+import org.citydb.config.ConfigException;
+import org.citydb.database.DatabaseManager;
+import org.citydb.database.DatabaseOptions;
+import org.citydb.database.connection.ConnectionDetails;
+import picocli.CommandLine;
+
+import java.io.OutputStream;
+import java.util.Objects;
+
+@CommandLine.Command(
+        name = "connect",
+        description = "Test connection to the database.")
+public class ConnectCommand implements Command {
+    @CommandLine.Mixin
+    private JsonOutputOptions outputOptions;
+
+    @CommandLine.ArgGroup(exclusive = false,
+            heading = "Database connection options:%n")
+    private ConnectionOptions connectionOptions;
+
+    @ConfigOption
+    private Config config;
+
+    private final Logger logger = LoggerManager.getInstance().getLogger(ConnectCommand.class);
+
+    @Override
+    public Integer call() throws ExecutionException {
+        DatabaseManager databaseManager = DatabaseManager.newInstance();
+        try {
+            return doConnect(databaseManager);
+        } finally {
+            databaseManager.disconnect();
+        }
+    }
+
+    private int doConnect(DatabaseManager databaseManager) throws ExecutionException {
+        ConnectionDetails connectionDetails = Objects.requireNonNullElseGet(connectionOptions, ConnectionOptions::new)
+                .toConnectionDetails(getDatabaseOptions())
+                .fillAbsentValuesFromEnv();
+
+        logger.info("Testing connection to database {}.", connectionDetails.toConnectString());
+        if (outputOptions.isOutputSpecified()) {
+            if (outputOptions.isWriteToStdout()) {
+                logger.info("Writing connection status as JSON to standard output.");
+            } else {
+                logger.info("Writing connection status to JSON file {}.", outputOptions.getFile());
+            }
+        }
+
+        try {
+            databaseManager.connect(connectionDetails);
+            handleSuccess(databaseManager);
+            return CommandLine.ExitCode.OK;
+        } catch (Exception e) {
+            handleFailure(connectionDetails, e);
+            return CommandLine.ExitCode.SOFTWARE;
+        }
+    }
+
+    private void handleSuccess(DatabaseManager databaseManager) throws ExecutionException {
+        logger.info("Connection successfully established.");
+        if (outputOptions.isOutputSpecified()) {
+            writeJson(ConnectionStatusBuilder.buildSuccess(databaseManager.getAdapter()));
+        }
+
+        if (!outputOptions.isWriteToStdout()) {
+            databaseManager.reportDatabaseInfo(logger::info);
+        }
+    }
+
+    private void handleFailure(ConnectionDetails connectionDetails, Exception e) throws ExecutionException {
+        if (outputOptions.isOutputSpecified()) {
+            if (outputOptions.isWriteToStdout()) {
+                logger.error("Failed to connect to the database.");
+            }
+
+            writeJson(ConnectionStatusBuilder.buildFailure(connectionDetails, e));
+        }
+
+        if (!outputOptions.isWriteToStdout()) {
+            throw new ExecutionException("Failed to connect to the database.", e);
+        }
+    }
+
+    private void writeJson(JSONObject object) throws ExecutionException {
+        try (OutputStream stream = outputOptions.openStream()) {
+            JSON.writeTo(stream, object, JSONWriter.Feature.WriteNulls, JSONWriter.Feature.PrettyFormatWith2Space);
+        } catch (Exception e) {
+            throw new ExecutionException("Failed to write connection status as JSON.", e);
+        }
+    }
+
+    private DatabaseOptions getDatabaseOptions() throws ExecutionException {
+        try {
+            return config.get(DatabaseOptions.class);
+        } catch (ConfigException e) {
+            throw new ExecutionException("Failed to get database options from config.", e);
+        }
+    }
+}

--- a/citydb-cli/src/main/java/org/citydb/cli/connect/ConnectionStatusBuilder.java
+++ b/citydb-cli/src/main/java/org/citydb/cli/connect/ConnectionStatusBuilder.java
@@ -1,0 +1,114 @@
+/*
+ * citydb-tool - Command-line tool for the 3D City Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2022-2025
+ * virtualcitysystems GmbH, Germany
+ * https://vc.systems/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.cli.connect;
+
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import org.citydb.database.DatabaseConstants;
+import org.citydb.database.adapter.DatabaseAdapter;
+import org.citydb.database.connection.ConnectionDetails;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class ConnectionStatusBuilder {
+
+    private ConnectionStatusBuilder() {
+    }
+
+    public static JSONObject buildSuccess(DatabaseAdapter adapter) {
+        return new JSONObject().fluentPut("connectionStatus", "success")
+                .fluentPut("connection", buildDatabaseConnection(adapter.getConnectionDetails()))
+                .fluentPut("database", buildDatabase(adapter));
+    }
+
+    public static JSONObject buildFailure(ConnectionDetails connectionDetails, Exception e) {
+        return new JSONObject().fluentPut("connectionStatus", "failure")
+                .fluentPut("connection", buildDatabaseConnection(connectionDetails))
+                .fluentPut("error", buildError(e));
+    }
+
+    private static JSONObject buildDatabaseConnection(ConnectionDetails connectionDetails) {
+        return new JSONObject().fluentPut("host", connectionDetails.getHost())
+                .fluentPut("port", connectionDetails.getPort())
+                .fluentPut("database", connectionDetails.getDatabase())
+                .fluentPut("schema", connectionDetails.getSchema())
+                .fluentPut("user", connectionDetails.getUser());
+    }
+
+    private static JSONObject buildDatabase(DatabaseAdapter adapter) {
+        return new JSONObject().fluentPut("name", DatabaseConstants.CITYDB_NAME)
+                .fluentPut("version", adapter.getDatabaseMetadata().getVersion().toString())
+                .fluentPut("dbms", buildDbms(adapter))
+                .fluentPut("hasChangelogEnabled", adapter.getDatabaseMetadata().isChangelogEnabled())
+                .fluentPut("crs", buildCrs(adapter));
+    }
+
+    private static JSONObject buildDbms(DatabaseAdapter adapter) {
+        JSONObject dbms = new JSONObject();
+        dbms.fluentPut("name", adapter.getDatabaseMetadata().getVendorProductName())
+                .fluentPut("version", adapter.getDatabaseMetadata().getVendorProductVersion());
+
+        if (adapter.getDatabaseMetadata().hasProperties()) {
+            dbms.put("properties", buildDbmsProperties(adapter));
+        }
+
+        return dbms;
+    }
+
+    private static JSONObject buildDbmsProperties(DatabaseAdapter adapter) {
+        JSONObject properties = new JSONObject();
+        adapter.getDatabaseMetadata().getProperties().forEach((id, property) -> {
+            properties.putObject(id)
+                    .fluentPut("name", property.getName())
+                    .fluentPut("value", property.getValue().orElse("n/a"));
+        });
+
+        return properties;
+    }
+
+    private static JSONObject buildCrs(DatabaseAdapter adapter) {
+        return new JSONObject().fluentPut("srid", adapter.getDatabaseMetadata().getSpatialReference().getSRID())
+                .fluentPut("identifier", adapter.getDatabaseMetadata().getSpatialReference().getIdentifier())
+                .fluentPut("name", adapter.getDatabaseMetadata().getSpatialReference().getName());
+    }
+
+    private static JSONObject buildError(Exception e) {
+        return new JSONObject().fluentPut("causes", buildCauses(e));
+    }
+
+    private static JSONArray buildCauses(Exception e) {
+        Throwable cause = e;
+        JSONArray causes = new JSONArray();
+        Set<String> messages = new LinkedHashSet<>();
+
+        do {
+            String message = cause.getMessage();
+            if (message != null && messages.add(message)) {
+                causes.add(new JSONObject().fluentPut("message", message)
+                        .fluentPut("exception", cause.getClass().getName()));
+            }
+        } while ((cause = cause.getCause()) != null);
+
+        return causes;
+    }
+}

--- a/resources/json-schema/connection-status.schema.json
+++ b/resources/json-schema/connection-status.schema.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://3dcitydb.org/citydb-tool/json-schema/@major@.@minor@/connection-status.schema.json",
+  "title": "Connection status schema",
+  "description": "JSON schema describing the connection status to a 3DCityDB.",
+  "type": "object",
+  "oneOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "connectionStatus",
+        "connection",
+        "database"
+      ],
+      "properties": {
+        "connectionStatus": {
+          "const": "success"
+        },
+        "connection": {
+          "$ref": "#/$defs/connection"
+        },
+        "database": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "version",
+            "dbms",
+            "hasChangelogEnabled",
+            "crs"
+          ],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "dbms": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "version"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                },
+                "properties": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^.*$": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "hasChangelogEnabled": {
+              "type": "boolean"
+            },
+            "crs": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "srid",
+                "identifier",
+                "name"
+              ],
+              "properties": {
+                "srid": {
+                  "type": "integer"
+                },
+                "identifier": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "connectionStatus",
+        "connection",
+        "error"
+      ],
+      "properties": {
+        "connectionStatus": {
+          "const": "failure"
+        },
+        "connection": {
+          "$ref": "#/$defs/connection"
+        },
+        "error": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "causes"
+          ],
+          "properties": {
+            "causes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "message",
+                  "exception"
+                ],
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "exception": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "connection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "host",
+        "port",
+        "database",
+        "schema",
+        "user"
+      ],
+      "properties": {
+        "host": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "port": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "database": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "user": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a simple but useful `connect` command that tests whether a connection to a 3DCityDB instance can be established. The command supports optional JSON output, which can either be printed to `stdout` or written to a file. This makes it easy for external tools to parse and process the connection status, enabling straightforward integration into scripts and pipelines.

Example usage:

```
# Print connection status to console
citydb connect -H host -d database -u username -p password

# Print connection status as JSON to stdout
citydb connect -H host -d database -u username -p password -o -

# Write connection status directly to a JSON file
citydb connect -H host -d database -u username -p password -o status.json

# Pipe connection status into a JSON file
citydb connect -H host -d database -u username -p password -o - > status.json
```