### PR TITLE
Add configurable texture output folder for appearance export

### DIFF
--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/appearance/TextureExporter.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/appearance/TextureExporter.java
@@ -27,13 +27,16 @@ public abstract class TextureExporter extends SurfaceDataExporter {
     public TextureExporter(ExportHelper helper) throws SQLException {
         super(helper);
         blobExporter = new BlobExporter(tableHelper.getTable(Table.TEX_IMAGE), "id", "image_data", helper);
+        AppearanceOptions appearanceOptions = helper.getOptions().getAppearanceOptions()
+                .orElseGet(AppearanceOptions::new);
+        String outputFolder = appearanceOptions.getTextureOutputFolder() != null ?
+                appearanceOptions.getTextureOutputFolder() :
+                ExportConstants.TEXTURE_DIR;
         externalFileHelper = ExternalFileHelper.newInstance(helper)
-                .withRelativeOutputFolder(ExportConstants.TEXTURE_DIR)
+                .withRelativeOutputFolder(outputFolder)
                 .withFileNamePrefix(ExportConstants.TEXTURE_PREFIX)
                 .createUniqueFileNames(true)
-                .withNumberOfBuckets(helper.getOptions().getAppearanceOptions()
-                        .orElseGet(AppearanceOptions::new)
-                        .getNumberOfTextureBuckets());
+                .withNumberOfBuckets(appearanceOptions.getNumberOfTextureBuckets());
     }
 
     protected <T extends Texture<?>> T doExport(T texture, ResultSet rs) throws ExportException, SQLException {

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/options/AppearanceOptions.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/options/AppearanceOptions.java
@@ -11,6 +11,7 @@ import java.util.Set;
 public class AppearanceOptions {
     private boolean exportAppearances = true;
     private int numberOfTextureBuckets;
+    private String textureOutputFolder;
     private Set<String> themes;
 
     public boolean isExportAppearances() {
@@ -28,6 +29,15 @@ public class AppearanceOptions {
 
     public AppearanceOptions setNumberOfTextureBuckets(int numberOfTextureBuckets) {
         this.numberOfTextureBuckets = numberOfTextureBuckets;
+        return this;
+    }
+
+    public String getTextureOutputFolder() {
+        return textureOutputFolder;
+    }
+
+    public AppearanceOptions setTextureOutputFolder(String textureOutputFolder) {
+        this.textureOutputFolder = textureOutputFolder;
         return this;
     }
 


### PR DESCRIPTION
Currently, textures are always exported to the fixed default relative folder `appearance`. This PR adds a new `textureOutputFolder` option to `AppearanceOptions`, allowing users to customize the relative folder where exported textures are written. 