### PR TITLE
ci: replace battila7/get-version-action (fix set-output & node deprecation)

### DIFF
--- a/.github/workflows/docker-build-push-release.yml
+++ b/.github/workflows/docker-build-push-release.yml
@@ -13,9 +13,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get release version without v
+      - name: Get release version
         id: release_version
-        uses: battila7/get-version-action@v2
+        env:
+          REF_NAME: ${{ github.event.release.tag_name || github.ref_name }}
+        run: |
+          version="${REF_NAME}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "version-without-v=${version#v}" >> "$GITHUB_OUTPUT"
       - name: set lower case owner name
         run: |
           echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}


### PR DESCRIPTION
## Why

`battila7/get-version-action@v2` declares the ancient **node12** runtime and internally uses the deprecated `set-output` workflow command, so it emits **both** the Node.js 20 and `set-output` deprecation warnings in the `build-push` release job:

> The `set-output` command is deprecated and will be disabled soon.
> Node.js 20 actions are deprecated. …

All other actions in this repo already run on the Node 24 runtime (checkout@v6, setup-java@v5, gradle/actions/setup-gradle@v6, docker/* v4–v7, short-sha@v4.0), so no version bumps are needed here — this is the only remaining offender.

## What

Replace the `battila7/get-version-action@v2` step in `docker-build-push-release.yml` with a small POSIX shell step that derives the version from the release tag and writes to `$GITHUB_OUTPUT`:

```yaml
- name: Get release version
  id: release_version
  env:
    REF_NAME: ${{ github.event.release.tag_name || github.ref_name }}
  run: |
    version="${REF_NAME}"
    echo "version=${version}" >> "$GITHUB_OUTPUT"
    echo "version-without-v=${version#v}" >> "$GITHUB_OUTPUT"
```

The `version` / `version-without-v` outputs (the only ones consumed downstream, in the `CITYDB_TOOL_VERSION` build-arg) are preserved, so the rest of the workflow is unchanged.

## Validation

- YAML parsed; `actionlint` clean.
- Shell logic unit-tested for `v1.2.3` / `1.2.3` tag forms → correct `version` / `version-without-v`.