### PR TITLE
Improve implicit geometry export

### DIFF
--- a/citydb-io-citygml/src/main/java/org/citydb/io/citygml/adapter/core/ImplicitGeometryAdapter.java
+++ b/citydb-io-citygml/src/main/java/org/citydb/io/citygml/adapter/core/ImplicitGeometryAdapter.java
@@ -13,7 +13,9 @@ import org.citydb.io.citygml.serializer.ModelSerializer;
 import org.citydb.io.citygml.writer.ModelSerializerHelper;
 import org.citydb.model.geometry.ImplicitGeometry;
 import org.citydb.model.geometry.Point;
+import org.citydb.model.property.ImplicitGeometryDescriptor;
 import org.citydb.model.property.ImplicitGeometryProperty;
+import org.citydb.model.property.ImplicitGeometryReference;
 import org.citygml4j.core.model.CityGMLVersion;
 import org.citygml4j.core.model.core.AbstractAppearanceProperty;
 import org.citygml4j.core.model.core.TransformationMatrix4x4;
@@ -47,19 +49,27 @@ public class ImplicitGeometryAdapter implements ModelBuilder<org.citygml4j.core.
                 target.setReferencePoint(new PointProperty(helper.getPoint(referencePoint))));
 
         ImplicitGeometry implicitGeometry = helper.getOrLookupObject(source);
-        if (implicitGeometry != null && implicitGeometry.hasAppearances()) {
-            implicitGeometry.getAppearances().forEach(property -> {
-                boolean isInline = target.getRelativeGeometry() != null
-                        && target.getRelativeGeometry().isSetInlineObject()
-                        && !helper.lookupAndPut(property.getObject());
-                if (helper.getCityGMLVersion() == CityGMLVersion.v3_0) {
-                    target.getAppearances().add(isInline
-                            ? new AbstractAppearanceProperty(helper.getAppearance(property.getObject()))
-                            : new AbstractAppearanceProperty("#" + property.getObject().getOrCreateObjectId()));
-                } else if (isInline) {
-                    helper.writeAsGlobalFeature(helper.getAppearance(property.getObject()));
-                }
-            });
+        if (implicitGeometry != null) {
+            if (implicitGeometry.hasAppearances()) {
+                implicitGeometry.getAppearances().forEach(property -> {
+                    boolean isInline = target.getRelativeGeometry() != null
+                            && target.getRelativeGeometry().isSetInlineObject()
+                            && !helper.lookupAndPut(property.getObject());
+                    if (helper.getCityGMLVersion() == CityGMLVersion.v3_0) {
+                        target.getAppearances().add(isInline
+                                ? new AbstractAppearanceProperty(helper.getAppearance(property.getObject()))
+                                : new AbstractAppearanceProperty("#" + property.getObject().getOrCreateObjectId()));
+                    } else if (isInline) {
+                        helper.writeAsGlobalFeature(helper.getAppearance(property.getObject()));
+                    }
+                });
+            }
+        } else if (helper.getCityGMLVersion() == CityGMLVersion.v3_0) {
+            source.getReference()
+                    .flatMap(ImplicitGeometryReference::getDescriptor)
+                    .filter(ImplicitGeometryDescriptor::hasAppearanceReferences)
+                    .ifPresent(descriptor -> descriptor.getAppearanceReferences().forEach(reference ->
+                            target.getAppearances().add(new AbstractAppearanceProperty("#" + reference))));
         }
     }
 }

--- a/citydb-io-citygml/src/main/java/org/citydb/io/citygml/adapter/geometry/builder/ImplicitGeometryHelper.java
+++ b/citydb-io-citygml/src/main/java/org/citydb/io/citygml/adapter/geometry/builder/ImplicitGeometryHelper.java
@@ -18,6 +18,7 @@ import org.citydb.model.geometry.Geometry;
 import org.citydb.model.geometry.ImplicitGeometry;
 import org.citydb.model.property.AppearanceProperty;
 import org.citydb.model.property.ImplicitGeometryProperty;
+import org.citydb.model.property.ImplicitGeometryReference;
 import org.citygml4j.core.model.core.AbstractAppearanceProperty;
 import org.slf4j.event.Level;
 import org.xmlobjects.gml.model.geometry.AbstractGeometry;
@@ -48,10 +49,11 @@ public class ImplicitGeometryHelper {
                 if (source.getRelativeGeometry().getHref() != null) {
                     String objectId = FeatureHelper.getIdFromReference(source.getRelativeGeometry().getHref());
                     if (helper.lookupAndPut(source.getRelativeGeometry())) {
-                        return ImplicitGeometryProperty.of(name, objectId);
+                        return ImplicitGeometryProperty.of(name, ImplicitGeometryReference.of(objectId,
+                                resolver.getDescriptor(objectId)));
                     } else {
-                        ImplicitGeometry target = resolver.getOrConvert(objectId,
-                                implicitGeometry -> buildImplicitGeometry(implicitGeometry, force2D));
+                        ImplicitGeometry target = resolver.getOrConvert(objectId, implicitGeometry ->
+                                buildImplicitGeometry(implicitGeometry, force2D));
                         if (target != null) {
                             return ImplicitGeometryProperty.of(name, target);
                         }
@@ -65,9 +67,9 @@ public class ImplicitGeometryHelper {
             } else if (source.getLibraryObject() != null) {
                 try {
                     ExternalFile libraryObject = helper.getExternalFile(source.getLibraryObject());
-                    return helper.lookupAndPut(libraryObject) ?
-                            ImplicitGeometryProperty.of(name, libraryObject.getOrCreateObjectId()) :
-                            ImplicitGeometryProperty.of(name, ImplicitGeometry.of(libraryObject));
+                    return helper.lookupAndPut(libraryObject)
+                            ? ImplicitGeometryProperty.of(name, ImplicitGeometryReference.of(libraryObject))
+                            : ImplicitGeometryProperty.of(name, ImplicitGeometry.of(libraryObject));
                 } catch (IOException e) {
                     helper.logOrThrow(Level.ERROR, helper.formatMessage(source, "Failed to read library object file " +
                             source.getLibraryObject() + "."), e);

--- a/citydb-io-citygml/src/main/java/org/citydb/io/citygml/adapter/geometry/serializer/GeometryHelper.java
+++ b/citydb-io-citygml/src/main/java/org/citydb/io/citygml/adapter/geometry/serializer/GeometryHelper.java
@@ -9,7 +9,9 @@ package org.citydb.io.citygml.adapter.geometry.serializer;
 import org.citydb.io.citygml.writer.ModelSerializerHelper;
 import org.citydb.model.common.ExternalFile;
 import org.citydb.model.geometry.*;
+import org.citydb.model.property.ImplicitGeometryDescriptor;
 import org.citydb.model.property.ImplicitGeometryProperty;
+import org.citydb.model.property.ImplicitGeometryReference;
 import org.citygml4j.core.model.core.ImplicitGeometry;
 import org.xmlobjects.gml.model.basictypes.Code;
 import org.xmlobjects.gml.model.basictypes.Sign;
@@ -243,25 +245,46 @@ public class GeometryHelper {
         if (source != null) {
             org.citydb.model.geometry.ImplicitGeometry implicitGeometry = helper.getOrLookupObject(source);
             if (implicitGeometry != null) {
-                ImplicitGeometry target = new ImplicitGeometry();
-                Geometry<?> geometry = implicitGeometry.getGeometry().orElse(null);
-                ExternalFile libraryObject = implicitGeometry.getLibraryObject().orElse(null);
-
-                if (geometry != null) {
-                    target.setRelativeGeometry(helper.lookupAndPut(implicitGeometry)
-                            ? new GeometryProperty<>("#" + geometry.getOrCreateObjectId())
-                            : new GeometryProperty<>(getGeometry(geometry, force3D)));
-                } else if (libraryObject != null) {
-                    target.setLibraryObject(libraryObject.getFileLocation());
-                    libraryObject.getMimeType().ifPresent(mimeType -> target.setMimeType(
-                            new Code(mimeType, libraryObject.getMimeTypeCodeSpace().orElse(null))));
-                }
-
-                return target;
+                return getImplicitGeometry(implicitGeometry, force3D);
+            } else {
+                return source.getReference()
+                        .flatMap(ImplicitGeometryReference::getDescriptor)
+                        .map(this::getImplicitGeometry)
+                        .orElse(null);
             }
         }
 
         return null;
+    }
+
+    private ImplicitGeometry getImplicitGeometry(org.citydb.model.geometry.ImplicitGeometry source, boolean force3D) {
+        ImplicitGeometry target = new ImplicitGeometry();
+        Geometry<?> geometry = source.getGeometry().orElse(null);
+        if (geometry != null) {
+            target.setRelativeGeometry(helper.lookupAndPut(source)
+                    ? new GeometryProperty<>("#" + geometry.getOrCreateObjectId())
+                    : new GeometryProperty<>(getGeometry(geometry, force3D)));
+        } else {
+            source.getLibraryObject().ifPresent(libraryObject -> setLibraryObject(target, libraryObject));
+        }
+
+        return target;
+    }
+
+    private ImplicitGeometry getImplicitGeometry(ImplicitGeometryDescriptor descriptor) {
+        ImplicitGeometry target = new ImplicitGeometry();
+        descriptor.getGeometryReference().ifPresentOrElse(
+                reference -> target.setRelativeGeometry(new GeometryProperty<>("#" + reference)),
+                () -> descriptor.getLibraryObject()
+                        .ifPresent(libraryObject -> setLibraryObject(target, libraryObject)));
+
+        return target;
+    }
+
+    private void setLibraryObject(ImplicitGeometry target, ExternalFile libraryObject) {
+        target.setLibraryObject(libraryObject.getFileLocation());
+        libraryObject.getMimeType().ifPresent(mimeType -> target.setMimeType(
+                new Code(mimeType, libraryObject.getMimeTypeCodeSpace().orElse(null))));
     }
 
     private PointProperty getPointProperty(org.citydb.model.geometry.Point source, int dimension) {

--- a/citydb-io-citygml/src/main/java/org/citydb/io/citygml/reader/preprocess/ImplicitGeometryResolver.java
+++ b/citydb-io-citygml/src/main/java/org/citydb/io/citygml/reader/preprocess/ImplicitGeometryResolver.java
@@ -10,6 +10,7 @@ import org.citydb.core.function.CheckedFunction;
 import org.citydb.io.citygml.builder.ModelBuildException;
 import org.citydb.io.citygml.reader.util.FeatureHelper;
 import org.citydb.io.reader.options.ImplicitGeometryScope;
+import org.citydb.model.property.ImplicitGeometryDescriptor;
 import org.citygml4j.core.model.core.AbstractAppearanceProperty;
 import org.citygml4j.core.model.core.AbstractFeature;
 import org.citygml4j.core.model.core.ImplicitGeometry;
@@ -28,6 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ImplicitGeometryResolver {
     private final Map<String, ImplicitGeometry> implicitGeometries = new ConcurrentHashMap<>();
     private final Map<String, org.citydb.model.geometry.ImplicitGeometry> converted = new ConcurrentHashMap<>();
+    private final Map<String, ImplicitGeometryDescriptor> descriptors = new ConcurrentHashMap<>();
     private final Map<String, Envelope> envelopes = new ConcurrentHashMap<>();
 
     private ImplicitGeometryScope scope = ImplicitGeometryScope.GLOBAL;
@@ -54,6 +56,10 @@ public class ImplicitGeometryResolver {
         return implicitGeometries.values();
     }
 
+    public ImplicitGeometryDescriptor getDescriptor(String objectId) {
+        return descriptors.get(objectId);
+    }
+
     public org.citydb.model.geometry.ImplicitGeometry getOrConvert(String objectId, Converter converter) throws ModelBuildException {
         boolean cacheResult = retainState || scope == ImplicitGeometryScope.TOP_LEVEL_FEATURE;
         if (cacheResult) {
@@ -77,8 +83,17 @@ public class ImplicitGeometryResolver {
     }
 
     private org.citydb.model.geometry.ImplicitGeometry consumeAndConvert(String objectId, Converter converter) throws ModelBuildException {
-        ImplicitGeometry implicitGeometry = implicitGeometries.remove(objectId);
-        return implicitGeometry != null ? converter.apply(implicitGeometry) : null;
+        ImplicitGeometry source = implicitGeometries.remove(objectId);
+        if (source != null) {
+            org.citydb.model.geometry.ImplicitGeometry target = converter.apply(source);
+            if (target != null) {
+                descriptors.putIfAbsent(objectId, ImplicitGeometryDescriptor.of(target));
+            }
+
+            return target;
+        }
+
+        return null;
     }
 
     public Envelope computeEnvelope(ImplicitGeometry implicitGeometry) {

--- a/citydb-io-citygml/src/main/java/org/citydb/io/citygml/writer/ModelSerializerHelper.java
+++ b/citydb-io-citygml/src/main/java/org/citydb/io/citygml/writer/ModelSerializerHelper.java
@@ -221,6 +221,7 @@ public class ModelSerializerHelper {
 
     public org.citydb.model.geometry.ImplicitGeometry getOrLookupObject(ImplicitGeometryProperty property) {
         return property.getObject().orElseGet(() -> property.getReference()
+                .map(ImplicitGeometryReference::getObjectId)
                 .map(preprocessor::lookupImplicitGeometry)
                 .orElse(null));
     }

--- a/citydb-model/src/main/java/org/citydb/model/address/AddressDescriptor.java
+++ b/citydb-model/src/main/java/org/citydb/model/address/AddressDescriptor.java
@@ -19,6 +19,6 @@ public class AddressDescriptor extends DatabaseDescriptor {
 
     @Override
     public AddressDescriptor copy() {
-        return AddressDescriptor.of(getId());
+        return new AddressDescriptor(getId());
     }
 }

--- a/citydb-model/src/main/java/org/citydb/model/appearance/AppearanceDescriptor.java
+++ b/citydb-model/src/main/java/org/citydb/model/appearance/AppearanceDescriptor.java
@@ -39,7 +39,7 @@ public class AppearanceDescriptor extends DatabaseDescriptor {
 
     @Override
     public AppearanceDescriptor copy() {
-        return AppearanceDescriptor.of(getId())
+        return new AppearanceDescriptor(getId())
                 .setFeatureId(featureId)
                 .setImplicitGeometryId(implicitGeometryId);
     }

--- a/citydb-model/src/main/java/org/citydb/model/appearance/SurfaceDataProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/appearance/SurfaceDataProperty.java
@@ -12,7 +12,7 @@ import org.citydb.model.util.CopySession;
 import java.util.Objects;
 import java.util.Optional;
 
-public class SurfaceDataProperty extends Child implements InlineOrByReferenceProperty<SurfaceData<?>> {
+public class SurfaceDataProperty extends Child implements InlineOrByReferenceProperty<SurfaceData<?>, String> {
     private SurfaceData<?> surfaceData;
     private String reference;
 

--- a/citydb-model/src/main/java/org/citydb/model/change/FeatureChangeDescriptor.java
+++ b/citydb-model/src/main/java/org/citydb/model/change/FeatureChangeDescriptor.java
@@ -33,6 +33,6 @@ public class FeatureChangeDescriptor extends DatabaseDescriptor {
 
     @Override
     public FeatureChangeDescriptor copy() {
-        return FeatureChangeDescriptor.of(getId(), objectClassId, featureId);
+        return new FeatureChangeDescriptor(getId(), objectClassId, featureId);
     }
 }

--- a/citydb-model/src/main/java/org/citydb/model/common/InlineOrByReferenceProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/common/InlineOrByReferenceProperty.java
@@ -7,14 +7,14 @@ package org.citydb.model.common;
 
 import java.util.Optional;
 
-public interface InlineOrByReferenceProperty<T extends Referencable> {
+public interface InlineOrByReferenceProperty<T extends Referencable, R> {
     Optional<T> getObject();
 
-    InlineOrByReferenceProperty<T> setObject(T object);
+    InlineOrByReferenceProperty<T, R> setObject(T object);
 
-    Optional<String> getReference();
+    Optional<R> getReference();
 
-    InlineOrByReferenceProperty<T> setReference(String reference);
+    InlineOrByReferenceProperty<T, R> setReference(R reference);
 
-    InlineOrByReferenceProperty<T> setReference(T referencedObject);
+    InlineOrByReferenceProperty<T, R> setReference(T referencedObject);
 }

--- a/citydb-model/src/main/java/org/citydb/model/feature/FeatureDescriptor.java
+++ b/citydb-model/src/main/java/org/citydb/model/feature/FeatureDescriptor.java
@@ -35,7 +35,7 @@ public class FeatureDescriptor extends DatabaseDescriptor {
 
     @Override
     public FeatureDescriptor copy() {
-        return FeatureDescriptor.of(getId(), objectClassId)
+        return new FeatureDescriptor(getId(), objectClassId)
                 .setSequenceId(sequenceId);
     }
 }

--- a/citydb-model/src/main/java/org/citydb/model/geometry/GeometryDescriptor.java
+++ b/citydb-model/src/main/java/org/citydb/model/geometry/GeometryDescriptor.java
@@ -25,6 +25,6 @@ public class GeometryDescriptor extends DatabaseDescriptor {
 
     @Override
     public GeometryDescriptor copy() {
-        return GeometryDescriptor.of(getId(), featureId);
+        return new GeometryDescriptor(getId(), featureId);
     }
 }

--- a/citydb-model/src/main/java/org/citydb/model/property/AddressProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/AddressProperty.java
@@ -15,7 +15,7 @@ import org.citydb.model.util.CopySession;
 import java.util.Objects;
 import java.util.Optional;
 
-public class AddressProperty extends Property<AddressProperty> implements InlineOrByReferenceProperty<Address> {
+public class AddressProperty extends Property<AddressProperty> implements InlineOrByReferenceProperty<Address, String> {
     private Address address;
     private String reference;
 

--- a/citydb-model/src/main/java/org/citydb/model/property/FeatureProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/FeatureProperty.java
@@ -14,7 +14,7 @@ import org.citydb.model.util.CopySession;
 import java.util.Objects;
 import java.util.Optional;
 
-public class FeatureProperty extends Property<FeatureProperty> implements InlineOrByReferenceProperty<Feature> {
+public class FeatureProperty extends Property<FeatureProperty> implements InlineOrByReferenceProperty<Feature, String> {
     private Feature feature;
     private String reference;
     private RelationType relationType;

--- a/citydb-model/src/main/java/org/citydb/model/property/ImplicitGeometryDescriptor.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/ImplicitGeometryDescriptor.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright virtualcitysystems GmbH <https://vc.systems>
+ */
+
+package org.citydb.model.property;
+
+import org.citydb.model.common.ExternalFile;
+import org.citydb.model.geometry.Geometry;
+import org.citydb.model.geometry.ImplicitGeometry;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+public class ImplicitGeometryDescriptor implements Serializable {
+    private String geometryReference;
+    private ExternalFile libraryObject;
+    private Set<String> appearanceReferences;
+
+    private ImplicitGeometryDescriptor(String geometryReference) {
+        this.geometryReference = geometryReference;
+    }
+
+    private ImplicitGeometryDescriptor(ExternalFile libraryObject) {
+        this.libraryObject = libraryObject != null ? libraryObject.copy() : null;
+    }
+
+    public static ImplicitGeometryDescriptor of(String geometryReference) {
+        return new ImplicitGeometryDescriptor(geometryReference);
+    }
+
+    public static ImplicitGeometryDescriptor of(ExternalFile libraryObject) {
+        return new ImplicitGeometryDescriptor(libraryObject);
+    }
+
+    public static ImplicitGeometryDescriptor of(ImplicitGeometry implicitGeometry) {
+        Objects.requireNonNull(implicitGeometry, "The implicit geometry must not be null.");
+        ImplicitGeometryDescriptor descriptor;
+
+        Geometry<?> geometry = implicitGeometry.getGeometry().orElse(null);
+        if (geometry != null) {
+            descriptor = new ImplicitGeometryDescriptor(geometry.getOrCreateObjectId());
+            implicitGeometry.getAppearances().forEach(property ->
+                    descriptor.addAppearanceReference(property.getObject().getOrCreateObjectId()));
+        } else {
+            descriptor = new ImplicitGeometryDescriptor(implicitGeometry.getLibraryObject()
+                    .orElseThrow(() -> new IllegalStateException("The implicit geometry contains neither a " +
+                            "geometry nor a library object.")));
+        }
+
+        return descriptor;
+    }
+
+    public Optional<String> getGeometryReference() {
+        return Optional.ofNullable(geometryReference);
+    }
+
+    public Optional<ExternalFile> getLibraryObject() {
+        return Optional.ofNullable(libraryObject);
+    }
+
+    public boolean hasAppearanceReferences() {
+        return appearanceReferences != null && !appearanceReferences.isEmpty();
+    }
+
+    public Set<String> getAppearanceReferences() {
+        if (appearanceReferences == null) {
+            appearanceReferences = new HashSet<>();
+        }
+
+        return appearanceReferences;
+    }
+
+    public ImplicitGeometryDescriptor setAppearanceReferences(Set<String> appearanceReferences) {
+        this.appearanceReferences = appearanceReferences;
+        return this;
+    }
+
+    public ImplicitGeometryDescriptor addAppearanceReference(String appearanceReference) {
+        if (appearanceReference != null) {
+            getAppearanceReferences().add(appearanceReference);
+        }
+
+        return this;
+    }
+
+    public ImplicitGeometryDescriptor copy() {
+        ImplicitGeometryDescriptor clone = geometryReference != null
+                ? new ImplicitGeometryDescriptor(geometryReference)
+                : new ImplicitGeometryDescriptor(libraryObject);
+
+        return clone.setAppearanceReferences(appearanceReferences != null
+                ? new HashSet<>(appearanceReferences)
+                : null);
+    }
+}

--- a/citydb-model/src/main/java/org/citydb/model/property/ImplicitGeometryProperty.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/ImplicitGeometryProperty.java
@@ -18,9 +18,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-public class ImplicitGeometryProperty extends Property<ImplicitGeometryProperty> implements InlineOrByReferenceProperty<ImplicitGeometry> {
+public class ImplicitGeometryProperty extends Property<ImplicitGeometryProperty> implements InlineOrByReferenceProperty<ImplicitGeometry, ImplicitGeometryReference> {
     private ImplicitGeometry implicitGeometry;
-    private String reference;
+    private ImplicitGeometryReference reference;
     private Matrix4x4 transformationMatrix;
     private Point referencePoint;
     private String lod;
@@ -35,7 +35,7 @@ public class ImplicitGeometryProperty extends Property<ImplicitGeometryProperty>
         this.implicitGeometry = asChild(implicitGeometry);
     }
 
-    private ImplicitGeometryProperty(Name name, String reference) {
+    private ImplicitGeometryProperty(Name name, ImplicitGeometryReference reference) {
         super(name, DataType.IMPLICIT_GEOMETRY_PROPERTY);
         Objects.requireNonNull(reference, "The reference must not be null.");
         this.reference = reference;
@@ -45,13 +45,13 @@ public class ImplicitGeometryProperty extends Property<ImplicitGeometryProperty>
         return new ImplicitGeometryProperty(name, implicitGeometry);
     }
 
-    public static ImplicitGeometryProperty of(Name name, String reference) {
+    public static ImplicitGeometryProperty of(Name name, ImplicitGeometryReference reference) {
         return new ImplicitGeometryProperty(name, reference);
     }
 
     public static ImplicitGeometryProperty asReference(Name name, ImplicitGeometry implicitGeometry) {
-        Objects.requireNonNull(implicitGeometry, "The referenced implicit geometry must not be null.");
-        return new ImplicitGeometryProperty(name, implicitGeometry.getOrCreateObjectId());
+        Objects.requireNonNull(implicitGeometry, "The implicit geometry must not be null.");
+        return new ImplicitGeometryProperty(name, ImplicitGeometryReference.of(implicitGeometry));
     }
 
     @Override
@@ -70,12 +70,12 @@ public class ImplicitGeometryProperty extends Property<ImplicitGeometryProperty>
     }
 
     @Override
-    public Optional<String> getReference() {
+    public Optional<ImplicitGeometryReference> getReference() {
         return Optional.ofNullable(reference);
     }
 
     @Override
-    public ImplicitGeometryProperty setReference(String reference) {
+    public ImplicitGeometryProperty setReference(ImplicitGeometryReference reference) {
         if (reference != null) {
             this.reference = reference;
             implicitGeometry = null;
@@ -86,7 +86,7 @@ public class ImplicitGeometryProperty extends Property<ImplicitGeometryProperty>
 
     @Override
     public ImplicitGeometryProperty setReference(ImplicitGeometry implicitGeometry) {
-        return implicitGeometry != null ? setReference(implicitGeometry.getOrCreateObjectId()) : this;
+        return implicitGeometry != null ? setReference(ImplicitGeometryReference.of(implicitGeometry)) : this;
     }
 
     public Optional<Matrix4x4> getTransformationMatrix() {
@@ -152,7 +152,7 @@ public class ImplicitGeometryProperty extends Property<ImplicitGeometryProperty>
         super.copyPropertiesTo(property, session);
 
         property.implicitGeometry = property.asChild(copy(implicitGeometry, session));
-        property.reference = reference;
+        property.reference = reference != null ? reference.copy() : null;
         property.transformationMatrix = transformationMatrix != null ? transformationMatrix.copy() : null;
         property.referencePoint = property.asChild(copy(referencePoint, session));
         property.lod = lod;

--- a/citydb-model/src/main/java/org/citydb/model/property/ImplicitGeometryReference.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/ImplicitGeometryReference.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright virtualcitysystems GmbH <https://vc.systems>
+ */
+
+package org.citydb.model.property;
+
+import org.citydb.model.common.ExternalFile;
+import org.citydb.model.geometry.ImplicitGeometry;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Optional;
+
+public class ImplicitGeometryReference implements Serializable {
+    private final String objectId;
+    private final ImplicitGeometryDescriptor descriptor;
+
+    private ImplicitGeometryReference(String objectId, ImplicitGeometryDescriptor descriptor) {
+        this.objectId = Objects.requireNonNull(objectId, "The object id must not be null.");
+        this.descriptor = descriptor;
+    }
+
+    public static ImplicitGeometryReference of(String objectId) {
+        return new ImplicitGeometryReference(objectId, null);
+    }
+
+    public static ImplicitGeometryReference of(String objectId, ImplicitGeometryDescriptor descriptor) {
+        return new ImplicitGeometryReference(objectId, descriptor != null ? descriptor.copy() : null);
+    }
+
+    public static ImplicitGeometryReference of(ImplicitGeometry implicitGeometry) {
+        Objects.requireNonNull(implicitGeometry, "The implicit geometry must not be null.");
+        return new ImplicitGeometryReference(implicitGeometry.getOrCreateObjectId(),
+                ImplicitGeometryDescriptor.of(implicitGeometry));
+    }
+
+    public static ImplicitGeometryReference of(ExternalFile libraryObject) {
+        Objects.requireNonNull(libraryObject, "The library object must not be null.");
+        return new ImplicitGeometryReference(libraryObject.getOrCreateObjectId(),
+                ImplicitGeometryDescriptor.of(libraryObject));
+    }
+
+    public String getObjectId() {
+        return objectId;
+    }
+
+    public Optional<ImplicitGeometryDescriptor> getDescriptor() {
+        return Optional.ofNullable(descriptor);
+    }
+
+    public ImplicitGeometryReference copy() {
+        return new ImplicitGeometryReference(objectId,
+                descriptor != null ? descriptor.copy() : null);
+    }
+}

--- a/citydb-model/src/main/java/org/citydb/model/property/PropertyDescriptor.java
+++ b/citydb-model/src/main/java/org/citydb/model/property/PropertyDescriptor.java
@@ -35,7 +35,7 @@ public class PropertyDescriptor extends DatabaseDescriptor {
 
     @Override
     public PropertyDescriptor copy() {
-        return PropertyDescriptor.of(getId(), featureId)
+        return new PropertyDescriptor(getId(), featureId)
                 .setParentId(parentId);
     }
 }

--- a/citydb-model/src/main/java/org/citydb/model/walker/ModelWalker.java
+++ b/citydb-model/src/main/java/org/citydb/model/walker/ModelWalker.java
@@ -221,7 +221,7 @@ public class ModelWalker implements Visitor {
         }
     }
 
-    public void visit(InlineOrByReferenceProperty<?> property) {
+    public void visit(InlineOrByReferenceProperty<?, ?> property) {
         if (property instanceof Property<?> object) {
             visit(object);
         }
@@ -236,11 +236,11 @@ public class ModelWalker implements Visitor {
     }
 
     public void visit(AddressProperty property) {
-        visit((InlineOrByReferenceProperty<?>) property);
+        visit((InlineOrByReferenceProperty<?, ?>) property);
     }
 
     public void visit(FeatureProperty property) {
-        visit((InlineOrByReferenceProperty<?>) property);
+        visit((InlineOrByReferenceProperty<?, ?>) property);
     }
 
     public void visit(GeometryProperty property) {
@@ -248,11 +248,11 @@ public class ModelWalker implements Visitor {
     }
 
     public void visit(SurfaceDataProperty property) {
-        visit((InlineOrByReferenceProperty<?>) property);
+        visit((InlineOrByReferenceProperty<?, ?>) property);
     }
 
     public void visit(ImplicitGeometryProperty property) {
-        visit((InlineOrByReferenceProperty<?>) property);
+        visit((InlineOrByReferenceProperty<?, ?>) property);
 
         if (shouldWalk) {
             property.getReferencePoint().ifPresent(referencePoint -> referencePoint.accept(this));

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/ExportHelper.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/ExportHelper.java
@@ -32,6 +32,7 @@ import java.util.Set;
 public class ExportHelper {
     private final DatabaseAdapter adapter;
     private final ExportOptions options;
+    private final ImplicitGeometryRegistry implicitGeometryRegistry;
     private final Connection connection;
     private final SchemaMapping schemaMapping;
     private final SpatialReference targetSrs;
@@ -46,9 +47,10 @@ public class ExportHelper {
     private final Set<String> addressIdCache = new HashSet<>();
     private final Set<String> externalFileIdCache = new HashSet<>();
 
-    ExportHelper(DatabaseAdapter adapter, ExportOptions options) throws SQLException, SrsException {
+    ExportHelper(DatabaseAdapter adapter, ExportOptions options, ImplicitGeometryRegistry implicitGeometryRegistry) throws SQLException, SrsException {
         this.adapter = adapter;
         this.options = options;
+        this.implicitGeometryRegistry = implicitGeometryRegistry;
 
         connection = adapter.getPool().getConnection();
         schemaMapping = adapter.getSchemaAdapter().getSchemaMapping();
@@ -66,6 +68,10 @@ public class ExportHelper {
 
     public ExportOptions getOptions() {
         return options;
+    }
+
+    public ImplicitGeometryRegistry getImplicitGeometryRegistry() {
+        return implicitGeometryRegistry;
     }
 
     public SchemaMapping getSchemaMapping() {

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/ExportOptions.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/ExportOptions.java
@@ -15,6 +15,7 @@ import org.citydb.model.common.Matrix3x4;
 import org.citydb.model.encoding.Matrix3x4Reader;
 import org.citydb.model.encoding.Matrix3x4Writer;
 import org.citydb.operation.exporter.options.AppearanceOptions;
+import org.citydb.operation.exporter.options.ImplicitGeometryScope;
 import org.citydb.operation.exporter.options.LodOptions;
 import org.citydb.operation.exporter.options.ValidityOptions;
 
@@ -40,6 +41,8 @@ public class ExportOptions {
 
     @JSONField(serialize = false, deserialize = false)
     private OutputFile outputFile;
+    @JSONField(serialize = false, deserialize = false)
+    private ImplicitGeometryScope implicitGeometryScope;
 
     public int getNumberOfThreads() {
         return numberOfThreads;
@@ -123,6 +126,15 @@ public class ExportOptions {
 
     public ExportOptions setOutputDirectory(Path outputDirectory) {
         outputFile = new RegularOutputFile(outputDirectory.resolve("output.tmp"));
+        return this;
+    }
+
+    public ImplicitGeometryScope getImplicitGeometryScope() {
+        return implicitGeometryScope != null ? implicitGeometryScope : ImplicitGeometryScope.GLOBAL;
+    }
+
+    public ExportOptions setImplicitGeometryScope(ImplicitGeometryScope implicitGeometryScope) {
+        this.implicitGeometryScope = implicitGeometryScope;
         return this;
     }
 }

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/Exporter.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/Exporter.java
@@ -11,6 +11,7 @@ import org.citydb.core.function.CheckedSupplier;
 import org.citydb.database.adapter.DatabaseAdapter;
 import org.citydb.model.feature.Feature;
 import org.citydb.model.geometry.ImplicitGeometry;
+import org.citydb.operation.exporter.util.ImplicitGeometryRegistry;
 
 import java.util.Objects;
 import java.util.Set;
@@ -20,6 +21,7 @@ import java.util.concurrent.ExecutorService;
 
 public class Exporter {
     private ExecutorService service;
+    private ImplicitGeometryRegistry implicitGeometryRegistry;
     private ThreadLocal<ExportHelper> contexts;
     private Set<ExportHelper> helpers;
     private CountLatch countLatch;
@@ -56,6 +58,8 @@ public class Exporter {
         Objects.requireNonNull(adapter, "The database adapter must not be null.");
         Objects.requireNonNull(options, "The export options must not be null.");
 
+        implicitGeometryRegistry = ImplicitGeometryRegistry.of(options.getImplicitGeometryScope());
+
         helpers = ConcurrentHashMap.newKeySet();
         service = ExecutorHelper.newFixedAndBlockingThreadPool(options.getNumberOfThreads() > 0
                 ? options.getNumberOfThreads()
@@ -64,7 +68,7 @@ public class Exporter {
         countLatch = new CountLatch();
         contexts = ThreadLocal.withInitial(() -> {
             try {
-                ExportHelper helper = new ExportHelper(adapter, options);
+                ExportHelper helper = new ExportHelper(adapter, options, implicitGeometryRegistry);
                 helpers.add(helper);
                 return helper;
             } catch (Exception e) {
@@ -132,6 +136,7 @@ public class Exporter {
             throw new ExportException("Failed to close export session.", e);
         } finally {
             service.shutdown();
+            implicitGeometryRegistry.clear();
         }
     }
 }

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/geometry/ImplicitGeometryExporter.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/geometry/ImplicitGeometryExporter.java
@@ -6,7 +6,6 @@
 package org.citydb.operation.exporter.geometry;
 
 import org.citydb.model.appearance.Appearance;
-import org.citydb.model.appearance.AppearanceDescriptor;
 import org.citydb.model.common.ExternalFile;
 import org.citydb.model.common.Name;
 import org.citydb.model.common.Namespaces;
@@ -27,7 +26,6 @@ import org.citydb.sqlbuilder.schema.Table;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class ImplicitGeometryExporter extends DatabaseExporter {
     private final BlobExporter blobExporter;
@@ -63,11 +61,11 @@ public class ImplicitGeometryExporter extends DatabaseExporter {
 
         setLongArrayOrNull(1, List.of(id));
         try (ResultSet rs = stmt.executeQuery()) {
-            return doExport(appearances, rs).get(id);
+            return doExport(Map.of(id, appearances), rs).get(id);
         }
     }
 
-    public Map<Long, ImplicitGeometry> doExport(Set<Long> ids, Collection<Appearance> appearances) throws ExportException, SQLException {
+    public Map<Long, ImplicitGeometry> doExport(Set<Long> ids, Map<Long, ? extends Collection<Appearance>> appearances) throws ExportException, SQLException {
         if (!ids.isEmpty()) {
             setLongArrayOrNull(1, ids);
             try (ResultSet rs = stmt.executeQuery()) {
@@ -78,14 +76,8 @@ public class ImplicitGeometryExporter extends DatabaseExporter {
         }
     }
 
-    private Map<Long, ImplicitGeometry> doExport(Collection<Appearance> appearances, ResultSet rs) throws ExportException, SQLException {
+    private Map<Long, ImplicitGeometry> doExport(Map<Long, ? extends Collection<Appearance>> appearancesById, ResultSet rs) throws ExportException, SQLException {
         Map<Long, ImplicitGeometry> implicitGeometries = new HashMap<>();
-        Map<Long, List<Appearance>> appearancesById = appearances.stream()
-                .filter(appearance -> appearance.getDescriptor()
-                        .map(AppearanceDescriptor::getImplicitGeometryId).isPresent())
-                .collect(Collectors.groupingBy(appearance -> appearance.getDescriptor()
-                        .map(AppearanceDescriptor::getImplicitGeometryId).orElse(0L)));
-
         while (rs.next()) {
             ImplicitGeometry implicitGeometry = null;
             long id = rs.getLong("id");
@@ -118,9 +110,12 @@ public class ImplicitGeometryExporter extends DatabaseExporter {
                 }
 
                 implicitGeometries.put(id, implicitGeometry);
-                for (Appearance appearance : appearancesById.getOrDefault(id, Collections.emptyList())) {
-                    implicitGeometry.addAppearance(
-                            AppearanceProperty.of(Name.of("appearance", Namespaces.APPEARANCE), appearance));
+                Collection<Appearance> appearances = appearancesById.get(id);
+                if (appearances != null) {
+                    for (Appearance appearance : appearances) {
+                        implicitGeometry.addAppearance(
+                                AppearanceProperty.of(Name.of("appearance", Namespaces.APPEARANCE), appearance));
+                    }
                 }
             }
         }

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/geometry/ImplicitGeometryExporter.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/geometry/ImplicitGeometryExporter.java
@@ -47,8 +47,8 @@ public class ImplicitGeometryExporter extends DatabaseExporter {
     private Select getQuery(Table implicitGeometry) {
         Table geometryData = tableHelper.getTable(org.citydb.database.schema.Table.GEOMETRY_DATA);
         return Select.newInstance()
-                .select(implicitGeometry.columns("id", "mime_type", "mime_type_codespace", "reference_to_library",
-                        "relative_geometry_id"))
+                .select(implicitGeometry.columns("id", "objectid", "mime_type", "mime_type_codespace",
+                        "reference_to_library", "relative_geometry_id"))
                 .select(geometryData.columns("implicit_geometry", "geometry_properties", "feature_id"))
                 .from(implicitGeometry)
                 .leftJoin(geometryData).on(geometryData.column("id")
@@ -112,6 +112,11 @@ public class ImplicitGeometryExporter extends DatabaseExporter {
             }
 
             if (implicitGeometry != null) {
+                String objectId = rs.getString("objectid");
+                if (!rs.wasNull()) {
+                    implicitGeometry.setObjectId(objectId);
+                }
+
                 implicitGeometries.put(id, implicitGeometry);
                 for (Appearance appearance : appearancesById.getOrDefault(id, Collections.emptyList())) {
                     implicitGeometry.addAppearance(

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/hierarchy/Hierarchy.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/hierarchy/Hierarchy.java
@@ -7,12 +7,15 @@ package org.citydb.operation.exporter.hierarchy;
 
 import org.citydb.model.address.Address;
 import org.citydb.model.appearance.Appearance;
+import org.citydb.model.appearance.AppearanceDescriptor;
 import org.citydb.model.feature.Feature;
 import org.citydb.model.geometry.Geometry;
 import org.citydb.model.geometry.ImplicitGeometry;
 import org.citydb.model.property.Property;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class Hierarchy {
@@ -20,6 +23,7 @@ public class Hierarchy {
     private final Map<Long, Geometry<?>> geometries = new HashMap<>();
     private final Map<Long, ImplicitGeometry> implicitGeometries = new HashMap<>();
     private final Map<Long, Appearance> appearances = new HashMap<>();
+    private final Map<Long, List<Appearance>> implicitGeometryAppearances = new HashMap<>();
     private final Map<Long, Address> addresses = new HashMap<>();
     private final Map<Long, Property<?>> properties = new HashMap<>();
 
@@ -76,9 +80,19 @@ public class Hierarchy {
         return id != null ? appearances.get(id) : null;
     }
 
+    public Map<Long, List<Appearance>> getImplicitGeometryAppearances() {
+        return implicitGeometryAppearances;
+    }
+
     public void addAppearance(long id, Appearance appearance) {
         if (appearance != null) {
             appearances.put(id, appearance);
+            appearance.getDescriptor()
+                    .map(AppearanceDescriptor::getImplicitGeometryId)
+                    .filter(implicitGeometryId -> implicitGeometryId != 0)
+                    .ifPresent(implicitGeometryId -> implicitGeometryAppearances
+                            .computeIfAbsent(implicitGeometryId, k -> new ArrayList<>())
+                            .add(appearance));
         }
     }
 

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/hierarchy/HierarchyBuilder.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/hierarchy/HierarchyBuilder.java
@@ -175,8 +175,8 @@ public class HierarchyBuilder {
                         .forEach(hierarchy::addAppearance);
             }
 
-            if (!implicitGeometryIds.isEmpty()) {
-                implicitGeometryRegistry.resolve(implicitGeometryIds, implicitGeometryIdsToExport, ids ->
+            if (!implicitGeometryIdsToExport.isEmpty()) {
+                implicitGeometryRegistry.resolve(implicitGeometryIdsToExport, ids ->
                                 tableHelper.getOrCreateExporter(ImplicitGeometryExporter.class)
                                         .doExport(ids, hierarchy.getAppearances().values()))
                         .forEach(hierarchy::addImplicitGeometry);

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/hierarchy/HierarchyBuilder.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/hierarchy/HierarchyBuilder.java
@@ -178,7 +178,7 @@ public class HierarchyBuilder {
             if (!implicitGeometryIdsToExport.isEmpty()) {
                 implicitGeometryRegistry.resolve(implicitGeometryIdsToExport, ids ->
                                 tableHelper.getOrCreateExporter(ImplicitGeometryExporter.class)
-                                        .doExport(ids, hierarchy.getAppearances().values()))
+                                        .doExport(ids, hierarchy.getImplicitGeometryAppearances()))
                         .forEach(hierarchy::addImplicitGeometry);
             }
         } catch (Exception e) {

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/hierarchy/HierarchyBuilder.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/hierarchy/HierarchyBuilder.java
@@ -20,6 +20,7 @@ import org.citydb.operation.exporter.geometry.ImplicitGeometryExporter;
 import org.citydb.operation.exporter.options.AppearanceOptions;
 import org.citydb.operation.exporter.property.PropertyExporter;
 import org.citydb.operation.exporter.property.PropertyStub;
+import org.citydb.operation.exporter.util.ImplicitGeometryRegistry;
 import org.citydb.operation.exporter.util.LodFilter;
 import org.citydb.operation.exporter.util.TableHelper;
 import org.citydb.operation.exporter.util.ValidityFilter;
@@ -31,6 +32,7 @@ import java.util.*;
 public class HierarchyBuilder {
     private final long rootId;
     private final ExportHelper helper;
+    private final ImplicitGeometryRegistry implicitGeometryRegistry;
     private final ValidityFilter validityFilter;
     private final LodFilter lodFilter;
     private final TableHelper tableHelper;
@@ -42,6 +44,8 @@ public class HierarchyBuilder {
     private HierarchyBuilder(long rootId, ExportHelper helper) {
         this.rootId = rootId;
         this.helper = helper;
+
+        implicitGeometryRegistry = helper.getImplicitGeometryRegistry();
         validityFilter = helper.getValidityFilter();
         lodFilter = helper.getLodFilter();
         tableHelper = helper.getTableHelper();
@@ -117,8 +121,8 @@ public class HierarchyBuilder {
 
     private void loadResources() throws ExportException, SQLException {
         Set<Long> geometryIds = new HashSet<>();
-        Set<Long> appearanceIds = new HashSet<>();
         Set<Long> addressIds = new HashSet<>();
+        Set<Long> appearanceIds = new HashSet<>();
         Set<Long> implicitGeometryIds = new HashSet<>();
 
         for (List<PropertyStub> propertyStubs : this.propertyStubs.values()) {
@@ -133,12 +137,12 @@ public class HierarchyBuilder {
                     }
                 }
 
-                if (exportAppearances && propertyStub.getAppearanceId() != null) {
-                    appearanceIds.add(propertyStub.getAppearanceId());
-                }
-
                 if (propertyStub.getAddressId() != null) {
                     addressIds.add(propertyStub.getAddressId());
+                }
+
+                if (exportAppearances && propertyStub.getAppearanceId() != null) {
+                    appearanceIds.add(propertyStub.getAppearanceId());
                 }
 
                 if (propertyStub.getImplicitGeometryId() != null) {
@@ -157,22 +161,29 @@ public class HierarchyBuilder {
                     .forEach(hierarchy::addGeometry);
         }
 
-        if (exportAppearances) {
-            tableHelper.getOrCreateExporter(AppearanceExporter.class)
-                    .doExport(appearanceIds, implicitGeometryIds)
-                    .forEach(hierarchy::addAppearance);
-        }
-
         if (!addressIds.isEmpty()) {
             tableHelper.getOrCreateExporter(AddressExporter.class)
                     .doExport(addressIds)
                     .forEach(hierarchy::addAddress);
         }
 
-        if (!implicitGeometryIds.isEmpty()) {
-            tableHelper.getOrCreateExporter(ImplicitGeometryExporter.class)
-                    .doExport(implicitGeometryIds, hierarchy.getAppearances().values())
-                    .forEach(hierarchy::addImplicitGeometry);
+        Set<Long> implicitGeometryIdsToExport = implicitGeometryRegistry.claim(implicitGeometryIds);
+        try {
+            if (exportAppearances) {
+                tableHelper.getOrCreateExporter(AppearanceExporter.class)
+                        .doExport(appearanceIds, implicitGeometryIdsToExport)
+                        .forEach(hierarchy::addAppearance);
+            }
+
+            if (!implicitGeometryIds.isEmpty()) {
+                implicitGeometryRegistry.resolve(implicitGeometryIds, implicitGeometryIdsToExport, ids ->
+                                tableHelper.getOrCreateExporter(ImplicitGeometryExporter.class)
+                                        .doExport(ids, hierarchy.getAppearances().values()))
+                        .forEach(hierarchy::addImplicitGeometry);
+            }
+        } catch (Exception e) {
+            implicitGeometryRegistry.fail(implicitGeometryIdsToExport, e);
+            throw e;
         }
     }
 

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/hierarchy/PropertyBuilder.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/hierarchy/PropertyBuilder.java
@@ -69,7 +69,7 @@ public class PropertyBuilder {
         ImplicitGeometry implicitGeometry = hierarchy.getImplicitGeometry(propertyStub.getImplicitGeometryId());
         if (implicitGeometry != null) {
             ImplicitGeometryProperty property = helper.lookupAndPut(implicitGeometry)
-                    ? ImplicitGeometryProperty.of(propertyStub.getName(), implicitGeometry.getOrCreateObjectId())
+                    ? ImplicitGeometryProperty.asReference(propertyStub.getName(), implicitGeometry)
                     : ImplicitGeometryProperty.of(propertyStub.getName(), implicitGeometry);
 
             if (propertyStub.getArrayValue() != null) {

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/hierarchy/PropertyBuilder.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/hierarchy/PropertyBuilder.java
@@ -76,10 +76,11 @@ public class PropertyBuilder {
                     ? ImplicitGeometryProperty.asReference(propertyStub.getName(), implicitGeometry)
                     : ImplicitGeometryProperty.of(propertyStub.getName(), implicitGeometry);
         } else {
-            String objectId = implicitGeometryRegistry.getObjectId(propertyStub.getImplicitGeometryId());
-            if (objectId != null) {
-                property = ImplicitGeometryProperty.of(propertyStub.getName(), ImplicitGeometryReference.of(objectId,
-                        implicitGeometryRegistry.getDescriptor(propertyStub.getImplicitGeometryId())));
+            ImplicitGeometryRegistry.Metadata metadata = implicitGeometryRegistry.getMetadata(
+                    propertyStub.getImplicitGeometryId());
+            if (metadata != null) {
+                property = ImplicitGeometryProperty.of(propertyStub.getName(),
+                        ImplicitGeometryReference.of(metadata.objectId(), metadata.descriptor()));
             }
         }
 

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/hierarchy/PropertyBuilder.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/hierarchy/PropertyBuilder.java
@@ -13,12 +13,15 @@ import org.citydb.model.geometry.ImplicitGeometry;
 import org.citydb.model.property.*;
 import org.citydb.operation.exporter.ExportHelper;
 import org.citydb.operation.exporter.property.PropertyStub;
+import org.citydb.operation.exporter.util.ImplicitGeometryRegistry;
 
 public class PropertyBuilder {
     private final ExportHelper helper;
+    private final ImplicitGeometryRegistry implicitGeometryRegistry;
 
     PropertyBuilder(ExportHelper helper) {
         this.helper = helper;
+        implicitGeometryRegistry = helper.getImplicitGeometryRegistry();
     }
 
     Property<?> build(PropertyStub propertyStub, Hierarchy hierarchy) {
@@ -66,12 +69,21 @@ public class PropertyBuilder {
     }
 
     private ImplicitGeometryProperty buildImplicitGeometryProperty(PropertyStub propertyStub, Hierarchy hierarchy) {
+        ImplicitGeometryProperty property = null;
         ImplicitGeometry implicitGeometry = hierarchy.getImplicitGeometry(propertyStub.getImplicitGeometryId());
         if (implicitGeometry != null) {
-            ImplicitGeometryProperty property = helper.lookupAndPut(implicitGeometry)
+            property = helper.lookupAndPut(implicitGeometry)
                     ? ImplicitGeometryProperty.asReference(propertyStub.getName(), implicitGeometry)
                     : ImplicitGeometryProperty.of(propertyStub.getName(), implicitGeometry);
+        } else {
+            String objectId = implicitGeometryRegistry.getObjectId(propertyStub.getImplicitGeometryId());
+            if (objectId != null) {
+                property = ImplicitGeometryProperty.of(propertyStub.getName(), ImplicitGeometryReference.of(objectId,
+                        implicitGeometryRegistry.getDescriptor(propertyStub.getImplicitGeometryId())));
+            }
+        }
 
+        if (property != null) {
             if (propertyStub.getArrayValue() != null) {
                 property.setTransformationMatrix(propertyStub.getArrayValue().getValues().stream()
                         .filter(Value::isDouble)
@@ -79,11 +91,11 @@ public class PropertyBuilder {
                         .toList());
             }
 
-            return property.setReferencePoint(propertyStub.getReferencePoint())
+            property.setReferencePoint(propertyStub.getReferencePoint())
                     .setLod(propertyStub.getLod());
         }
 
-        return null;
+        return property;
     }
 
     private AppearanceProperty buildAppearanceProperty(PropertyStub propertyStub, Hierarchy hierarchy) {

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/options/ImplicitGeometryScope.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/options/ImplicitGeometryScope.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright virtualcitysystems GmbH <https://vc.systems>
+ */
+
+package org.citydb.operation.exporter.options;
+
+public enum ImplicitGeometryScope {
+    GLOBAL,
+    TOP_LEVEL_FEATURE
+}

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/util/EnvelopeHelper.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/util/EnvelopeHelper.java
@@ -13,42 +13,32 @@ import org.citydb.model.geometry.ImplicitGeometry;
 import org.citydb.model.geometry.Point;
 import org.citydb.model.property.FeatureProperty;
 import org.citydb.model.property.ImplicitGeometryProperty;
+import org.citydb.model.property.ImplicitGeometryReference;
 import org.citydb.model.property.RelationType;
+import org.citydb.model.util.AffineTransformer;
 import org.citydb.model.util.GeometryInfo;
+import org.citydb.model.util.matrix.Matrix;
 import org.citydb.model.walker.ModelWalker;
 import org.citydb.operation.exporter.ExportHelper;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.HashMap;
-import java.util.Map;
 
 public class EnvelopeHelper {
     private final ExportHelper helper;
+    private final ImplicitGeometryRegistry implicitGeometryRegistry;
 
     EnvelopeHelper(ExportHelper helper) {
         this.helper = helper;
+        implicitGeometryRegistry = helper.getImplicitGeometryRegistry();
     }
 
     public void updateEnvelope(Feature feature) {
-        Map<String, ImplicitGeometry> implicitGeometries = new HashMap<>();
-        feature.accept(new ModelWalker() {
-            @Override
-            public void visit(ImplicitGeometry implicitGeometry) {
-                implicitGeometry.getObjectId().ifPresent(objectId ->
-                        implicitGeometries.put(objectId, implicitGeometry));
-            }
-        });
-
-        updateEnvelope(feature, implicitGeometries);
-    }
-
-    private void updateEnvelope(Feature feature, Map<String, ImplicitGeometry> implicitGeometries) {
         Deque<Envelope> envelopes = new ArrayDeque<>();
         feature.accept(new ModelWalker() {
             @Override
             public void visit(Feature feature) {
-                envelopes.push(computeEnvelope(feature, implicitGeometries));
+                envelopes.push(computeEnvelope(feature));
                 super.visit(feature);
 
                 Envelope envelope = envelopes.pop();
@@ -69,7 +59,7 @@ public class EnvelopeHelper {
         });
     }
 
-    private Envelope computeEnvelope(Feature feature, Map<String, ImplicitGeometry> implicitGeometries) {
+    private Envelope computeEnvelope(Feature feature) {
         Envelope envelope = Envelope.empty();
         GeometryInfo geometryInfo = feature.getGeometryInfo(GeometryInfo.Mode.SKIP_NESTED_FEATURES);
 
@@ -86,15 +76,26 @@ public class EnvelopeHelper {
                     Matrix4x4 transformationMatrix = property.getTransformationMatrix().orElse(null);
                     Point referencePoint = property.getReferencePoint().orElse(null);
                     if (transformationMatrix != null && referencePoint != null) {
-                        ImplicitGeometry geometry = property.getObject().orElse(
-                                implicitGeometries.get(property.getReference().orElse(null)));
+                        ImplicitGeometry geometry = property.getObject().orElse(null);
                         if (geometry != null) {
                             envelope.include(geometry.getEnvelope(transformationMatrix, referencePoint));
                         } else {
-                            envelope.include(Point.of(Coordinate.of(
-                                    referencePoint.getCoordinate().getX() + transformationMatrix.get(0, 3),
-                                    referencePoint.getCoordinate().getY() + transformationMatrix.get(1, 3),
-                                    referencePoint.getCoordinate().getZ() + transformationMatrix.get(2, 3))));
+                            Envelope extent = implicitGeometryRegistry.getEnvelope(property.getReference()
+                                    .map(ImplicitGeometryReference::getObjectId)
+                                    .orElse(null));
+                            if (extent != null) {
+                                AffineTransformer.of(transformationMatrix.plus(new Matrix(4, 4)
+                                                .set(0, 3, referencePoint.getCoordinate().getX())
+                                                .set(1, 3, referencePoint.getCoordinate().getY())
+                                                .set(2, 3, referencePoint.getCoordinate().getZ())))
+                                        .transform(extent);
+                                envelope.include(extent);
+                            } else {
+                                envelope.include(Point.of(Coordinate.of(
+                                        referencePoint.getCoordinate().getX() + transformationMatrix.get(0, 3),
+                                        referencePoint.getCoordinate().getY() + transformationMatrix.get(1, 3),
+                                        referencePoint.getCoordinate().getZ() + transformationMatrix.get(2, 3))));
+                            }
                         }
                     }
                 }

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/util/ImplicitGeometryRegistry.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/util/ImplicitGeometryRegistry.java
@@ -13,7 +13,6 @@ import org.citydb.operation.exporter.options.ImplicitGeometryScope;
 
 import java.sql.SQLException;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -21,10 +20,12 @@ import java.util.stream.Collectors;
 
 public class ImplicitGeometryRegistry {
     private final ImplicitGeometryScope scope;
-    private final Map<Long, String> objectIds = new ConcurrentHashMap<>();
+    private final Map<Long, Metadata> metadata = new ConcurrentHashMap<>();
     private final Map<String, Envelope> envelopes = new ConcurrentHashMap<>();
-    private final Map<Long, ImplicitGeometryDescriptor> descriptors = new ConcurrentHashMap<>();
     private final Map<Long, CompletableFuture<Void>> pending = new ConcurrentHashMap<>();
+
+    public record Metadata(String objectId, ImplicitGeometryDescriptor descriptor) {
+    }
 
     private ImplicitGeometryRegistry(ImplicitGeometryScope scope) {
         this.scope = scope != null ? scope : ImplicitGeometryScope.GLOBAL;
@@ -34,8 +35,13 @@ public class ImplicitGeometryRegistry {
         return new ImplicitGeometryRegistry(scope);
     }
 
-    public String getObjectId(Long id) {
-        return id != null ? objectIds.get(id) : null;
+    public Metadata getMetadata(Long id) {
+        if (id != null) {
+            await(id);
+            return metadata.get(id);
+        }
+
+        return null;
     }
 
     public Envelope getEnvelope(String objectId) {
@@ -43,14 +49,10 @@ public class ImplicitGeometryRegistry {
         return envelope != null ? envelope.copy() : null;
     }
 
-    public ImplicitGeometryDescriptor getDescriptor(Long id) {
-        return id != null ? descriptors.get(id) : null;
-    }
-
     public Set<Long> claim(Set<Long> ids) {
         if (scope == ImplicitGeometryScope.GLOBAL) {
             return ids.stream()
-                    .filter(id -> !descriptors.containsKey(id))
+                    .filter(id -> !metadata.containsKey(id))
                     .filter(id -> pending.putIfAbsent(id, new CompletableFuture<>()) == null)
                     .collect(Collectors.collectingAndThen(Collectors.toSet(), Set::copyOf));
         } else {
@@ -62,13 +64,13 @@ public class ImplicitGeometryRegistry {
         ids.forEach(id -> fail(id, cause));
     }
 
-    public Map<Long, ImplicitGeometry> resolve(Set<Long> implicitGeometryIds, Set<Long> claimedIds, ImplicitGeometryLoader loader) throws ExportException, SQLException {
+    public Map<Long, ImplicitGeometry> resolve(Set<Long> claimedIds, ImplicitGeometryLoader loader) throws ExportException, SQLException {
         return scope == ImplicitGeometryScope.TOP_LEVEL_FEATURE
-                ? loader.load(implicitGeometryIds)
-                : resolveGlobal(implicitGeometryIds, claimedIds, loader);
+                ? loader.load(claimedIds)
+                : resolveGlobal(claimedIds, loader);
     }
 
-    private Map<Long, ImplicitGeometry> resolveGlobal(Set<Long> implicitGeometryIds, Set<Long> claimedIds, ImplicitGeometryLoader loader) throws ExportException, SQLException {
+    private Map<Long, ImplicitGeometry> resolveGlobal(Set<Long> claimedIds, ImplicitGeometryLoader loader) throws ExportException, SQLException {
         try {
             Map<Long, ImplicitGeometry> implicitGeometries = !claimedIds.isEmpty()
                     ? loader.load(claimedIds)
@@ -78,17 +80,17 @@ public class ImplicitGeometryRegistry {
             }
 
             claimedIds.forEach(this::complete);
-            implicitGeometryIds.stream()
-                    .filter(id -> !claimedIds.contains(id))
-                    .filter(id -> !descriptors.containsKey(id))
-                    .map(pending::get)
-                    .filter(Objects::nonNull)
-                    .forEach(CompletableFuture::join);
-
             return implicitGeometries;
         } catch (Exception e) {
             claimedIds.forEach(id -> fail(id, e));
             throw e;
+        }
+    }
+
+    private void await(Long id) {
+        CompletableFuture<Void> future = pending.get(id);
+        if (future != null) {
+            future.join();
         }
     }
 
@@ -108,15 +110,13 @@ public class ImplicitGeometryRegistry {
 
     private void registerMetadata(Long id, ImplicitGeometry implicitGeometry) {
         String objectId = implicitGeometry.getOrCreateObjectId();
-        objectIds.put(id, objectId);
-        descriptors.put(id, ImplicitGeometryDescriptor.of(implicitGeometry));
+        metadata.put(id, new Metadata(objectId, ImplicitGeometryDescriptor.of(implicitGeometry)));
         implicitGeometry.getGeometry().ifPresent(geometry -> envelopes.put(objectId, geometry.getEnvelope().copy()));
     }
 
     public void clear() {
-        objectIds.clear();
+        metadata.clear();
         envelopes.clear();
-        descriptors.clear();
         pending.clear();
     }
 

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/util/ImplicitGeometryRegistry.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/util/ImplicitGeometryRegistry.java
@@ -20,9 +20,8 @@ import java.util.stream.Collectors;
 
 public class ImplicitGeometryRegistry {
     private final ImplicitGeometryScope scope;
-    private final Map<Long, Metadata> metadata = new ConcurrentHashMap<>();
+    private final Map<Long, CompletableFuture<Metadata>> metadata = new ConcurrentHashMap<>();
     private final Map<String, Envelope> envelopes = new ConcurrentHashMap<>();
-    private final Map<Long, CompletableFuture<Void>> pending = new ConcurrentHashMap<>();
 
     public record Metadata(String objectId, ImplicitGeometryDescriptor descriptor) {
     }
@@ -37,8 +36,8 @@ public class ImplicitGeometryRegistry {
 
     public Metadata getMetadata(Long id) {
         if (id != null) {
-            await(id);
-            return metadata.get(id);
+            CompletableFuture<Metadata> future = metadata.get(id);
+            return future != null ? future.join() : null;
         }
 
         return null;
@@ -52,8 +51,7 @@ public class ImplicitGeometryRegistry {
     public Set<Long> claim(Set<Long> ids) {
         if (scope == ImplicitGeometryScope.GLOBAL) {
             return ids.stream()
-                    .filter(id -> !metadata.containsKey(id))
-                    .filter(id -> pending.putIfAbsent(id, new CompletableFuture<>()) == null)
+                    .filter(id -> metadata.putIfAbsent(id, new CompletableFuture<>()) == null)
                     .collect(Collectors.collectingAndThen(Collectors.toSet(), Set::copyOf));
         } else {
             return ids;
@@ -76,10 +74,13 @@ public class ImplicitGeometryRegistry {
                     ? loader.load(claimedIds)
                     : Map.of();
             for (Map.Entry<Long, ImplicitGeometry> entry : implicitGeometries.entrySet()) {
-                registerMetadata(entry.getKey(), entry.getValue());
+                complete(entry.getKey(), registerMetadata(entry.getValue()));
             }
 
-            claimedIds.forEach(this::complete);
+            claimedIds.stream()
+                    .filter(id -> !implicitGeometries.containsKey(id))
+                    .forEach(id -> complete(id, null));
+
             return implicitGeometries;
         } catch (Exception e) {
             claimedIds.forEach(id -> fail(id, e));
@@ -87,37 +88,29 @@ public class ImplicitGeometryRegistry {
         }
     }
 
-    private void await(Long id) {
-        CompletableFuture<Void> future = pending.get(id);
+    private void complete(Long id, Metadata metadata) {
+        CompletableFuture<Metadata> future = this.metadata.get(id);
         if (future != null) {
-            future.join();
-        }
-    }
-
-    private void complete(Long id) {
-        CompletableFuture<Void> future = pending.get(id);
-        if (future != null) {
-            future.complete(null);
+            future.complete(metadata);
         }
     }
 
     private void fail(Long id, Throwable cause) {
-        CompletableFuture<Void> future = pending.get(id);
+        CompletableFuture<Metadata> future = metadata.get(id);
         if (future != null) {
             future.completeExceptionally(cause);
         }
     }
 
-    private void registerMetadata(Long id, ImplicitGeometry implicitGeometry) {
+    private Metadata registerMetadata(ImplicitGeometry implicitGeometry) {
         String objectId = implicitGeometry.getOrCreateObjectId();
-        metadata.put(id, new Metadata(objectId, ImplicitGeometryDescriptor.of(implicitGeometry)));
         implicitGeometry.getGeometry().ifPresent(geometry -> envelopes.put(objectId, geometry.getEnvelope().copy()));
+        return new Metadata(objectId, ImplicitGeometryDescriptor.of(implicitGeometry));
     }
 
     public void clear() {
-        metadata.clear();
         envelopes.clear();
-        pending.clear();
+        metadata.clear();
     }
 
     @FunctionalInterface

--- a/citydb-operation/src/main/java/org/citydb/operation/exporter/util/ImplicitGeometryRegistry.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/exporter/util/ImplicitGeometryRegistry.java
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright virtualcitysystems GmbH <https://vc.systems>
+ */
+
+package org.citydb.operation.exporter.util;
+
+import org.citydb.model.geometry.Envelope;
+import org.citydb.model.geometry.ImplicitGeometry;
+import org.citydb.model.property.ImplicitGeometryDescriptor;
+import org.citydb.operation.exporter.ExportException;
+import org.citydb.operation.exporter.options.ImplicitGeometryScope;
+
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+public class ImplicitGeometryRegistry {
+    private final ImplicitGeometryScope scope;
+    private final Map<Long, String> objectIds = new ConcurrentHashMap<>();
+    private final Map<String, Envelope> envelopes = new ConcurrentHashMap<>();
+    private final Map<Long, ImplicitGeometryDescriptor> descriptors = new ConcurrentHashMap<>();
+    private final Map<Long, CompletableFuture<Void>> pending = new ConcurrentHashMap<>();
+
+    private ImplicitGeometryRegistry(ImplicitGeometryScope scope) {
+        this.scope = scope != null ? scope : ImplicitGeometryScope.GLOBAL;
+    }
+
+    public static ImplicitGeometryRegistry of(ImplicitGeometryScope scope) {
+        return new ImplicitGeometryRegistry(scope);
+    }
+
+    public String getObjectId(Long id) {
+        return id != null ? objectIds.get(id) : null;
+    }
+
+    public Envelope getEnvelope(String objectId) {
+        Envelope envelope = objectId != null ? envelopes.get(objectId) : null;
+        return envelope != null ? envelope.copy() : null;
+    }
+
+    public ImplicitGeometryDescriptor getDescriptor(Long id) {
+        return id != null ? descriptors.get(id) : null;
+    }
+
+    public Set<Long> claim(Set<Long> ids) {
+        if (scope == ImplicitGeometryScope.GLOBAL) {
+            return ids.stream()
+                    .filter(id -> !descriptors.containsKey(id))
+                    .filter(id -> pending.putIfAbsent(id, new CompletableFuture<>()) == null)
+                    .collect(Collectors.collectingAndThen(Collectors.toSet(), Set::copyOf));
+        } else {
+            return ids;
+        }
+    }
+
+    public void fail(Set<Long> ids, Throwable cause) {
+        ids.forEach(id -> fail(id, cause));
+    }
+
+    public Map<Long, ImplicitGeometry> resolve(Set<Long> implicitGeometryIds, Set<Long> claimedIds, ImplicitGeometryLoader loader) throws ExportException, SQLException {
+        return scope == ImplicitGeometryScope.TOP_LEVEL_FEATURE
+                ? loader.load(implicitGeometryIds)
+                : resolveGlobal(implicitGeometryIds, claimedIds, loader);
+    }
+
+    private Map<Long, ImplicitGeometry> resolveGlobal(Set<Long> implicitGeometryIds, Set<Long> claimedIds, ImplicitGeometryLoader loader) throws ExportException, SQLException {
+        try {
+            Map<Long, ImplicitGeometry> implicitGeometries = !claimedIds.isEmpty()
+                    ? loader.load(claimedIds)
+                    : Map.of();
+            for (Map.Entry<Long, ImplicitGeometry> entry : implicitGeometries.entrySet()) {
+                registerMetadata(entry.getKey(), entry.getValue());
+            }
+
+            claimedIds.forEach(this::complete);
+            implicitGeometryIds.stream()
+                    .filter(id -> !claimedIds.contains(id))
+                    .filter(id -> !descriptors.containsKey(id))
+                    .map(pending::get)
+                    .filter(Objects::nonNull)
+                    .forEach(CompletableFuture::join);
+
+            return implicitGeometries;
+        } catch (Exception e) {
+            claimedIds.forEach(id -> fail(id, e));
+            throw e;
+        }
+    }
+
+    private void complete(Long id) {
+        CompletableFuture<Void> future = pending.get(id);
+        if (future != null) {
+            future.complete(null);
+        }
+    }
+
+    private void fail(Long id, Throwable cause) {
+        CompletableFuture<Void> future = pending.get(id);
+        if (future != null) {
+            future.completeExceptionally(cause);
+        }
+    }
+
+    private void registerMetadata(Long id, ImplicitGeometry implicitGeometry) {
+        String objectId = implicitGeometry.getOrCreateObjectId();
+        objectIds.put(id, objectId);
+        descriptors.put(id, ImplicitGeometryDescriptor.of(implicitGeometry));
+        implicitGeometry.getGeometry().ifPresent(geometry -> envelopes.put(objectId, geometry.getEnvelope().copy()));
+    }
+
+    public void clear() {
+        objectIds.clear();
+        envelopes.clear();
+        descriptors.clear();
+        pending.clear();
+    }
+
+    @FunctionalInterface
+    public interface ImplicitGeometryLoader {
+        Map<Long, ImplicitGeometry> load(Set<Long> ids) throws ExportException, SQLException;
+    }
+}

--- a/citydb-operation/src/main/java/org/citydb/operation/importer/property/ImplicitGeometryPropertyImporter.java
+++ b/citydb-operation/src/main/java/org/citydb/operation/importer/property/ImplicitGeometryPropertyImporter.java
@@ -9,6 +9,7 @@ import com.alibaba.fastjson2.JSONArray;
 import org.citydb.database.schema.Sequence;
 import org.citydb.model.geometry.ImplicitGeometry;
 import org.citydb.model.property.ImplicitGeometryProperty;
+import org.citydb.model.property.ImplicitGeometryReference;
 import org.citydb.model.property.PropertyDescriptor;
 import org.citydb.model.util.matrix.Matrix;
 import org.citydb.operation.importer.ImportException;
@@ -53,8 +54,8 @@ public class ImplicitGeometryPropertyImporter extends PropertyImporter {
         } else {
             String reference = implicitGeometry != null
                     ? implicitGeometry.getOrCreateObjectId()
-                    : property.getReference().orElseThrow(() -> new ImportException(
-                    "The implicit geometry property contains neither an object nor a reference."));
+                    : property.getReference().map(ImplicitGeometryReference::getObjectId).orElseThrow(() ->
+                    new ImportException("The implicit geometry property contains neither an object nor a reference."));
             cacheReference(CacheType.IMPLICIT_GEOMETRY, reference, propertyId);
             stmt.setNull(8, Types.BIGINT);
         }


### PR DESCRIPTION
This PR introduces a new export option, `ImplicitGeometryScope`, which supports the values `GLOBAL` and `TOP_LEVEL_FEATURE`.

With `TOP_LEVEL_FEATURE`, implicit geometries are exported separately for each top-level feature. This is the current behavior of citydb-tool. The advantage is that each top-level feature is self-contained, and references to implicit geometries in other top-level features cannot occur. However, exports can be slow, especially when large implicit geometries are reused frequently.

With `GLOBAL`, each implicit geometry is exported only once and stored inline in a single top-level feature. Other top-level features that use the same implicit geometry reference it instead. This can substantially improve export performance but requires resolving references across top-level features.

`GLOBAL` is the new default scope.

